### PR TITLE
PR for 0.1.9 release

### DIFF
--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.1.8'
+DSUB_VERSION = '0.1.9.dev0'

--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.1.9.dev0'
+DSUB_VERSION = '0.1.9'

--- a/dsub/commands/ddel.py
+++ b/dsub/commands/ddel.py
@@ -71,19 +71,21 @@ def _parse_arguments():
       help='User labels to match. Tasks returned must match all labels.',
       metavar='KEY=VALUE')
 
-  # Add provider-specific arguments
-  google = parser.add_argument_group(
-      title='google',
-      description='Options for the Google provider (Pipelines API)')
-  google.add_argument(
+  # Shared arguments between the "google" and "google-v2" providers
+  google_common = parser.add_argument_group(
+      title='google-common',
+      description='Options common to the "google" and "google-v2" providers')
+  google_common.add_argument(
       '--project',
       help='Cloud project ID in which to find and delete the job(s)')
 
-  return provider_base.parse_args(parser, {
-      'google': ['project'],
-      'test-fails': [],
-      'local': [],
-  }, sys.argv[1:])
+  return provider_base.parse_args(
+      parser, {
+          'google': ['project'],
+          'google-v2': ['project'],
+          'test-fails': [],
+          'local': [],
+      }, sys.argv[1:])
 
 
 def _emit_search_criteria(user_ids, job_ids, task_ids, labels):

--- a/dsub/commands/dstat.py
+++ b/dsub/commands/dstat.py
@@ -288,6 +288,7 @@ def _prepare_row(task, full, summary):
       row_spec('labels', True, {}),
       row_spec('provider', True, None),
       row_spec('provider-attributes', True, {}),
+      row_spec('events', True, []),
       row_spec('dsub-version', False, None),
   ]
   summary_columns = default_columns + [

--- a/dsub/commands/dsub.py
+++ b/dsub/commands/dsub.py
@@ -359,6 +359,24 @@ def _parse_arguments(prog, argv):
       help="""Space-separated scopes for Google Compute Engine instances.
           If unspecified, provider will use '%s'""" % ','.join(
               google_base.DEFAULT_SCOPES))
+  google_common.add_argument(
+      '--accelerator-type',
+      help="""The Compute Engine accelerator type. By specifying this parameter,
+          you will download and install the following third-party software onto
+          your job's Compute Engine instances: NVIDIA(R) Tesla(R) drivers and
+          NVIDIA(R) CUDA toolkit. Please see
+          https://cloud.google.com/compute/docs/gpus/ for supported GPU types
+          and
+          https://cloud.google.com/genomics/reference/rest/v1alpha2/pipelines#pipelineresources
+          for more details.""")
+  google_common.add_argument(
+      '--accelerator-count',
+      type=int,
+      default=0,
+      help="""The number of accelerators of the specified type to attach.
+          By specifying this parameter, you will download and install the
+          following third-party software onto your job's Compute Engine
+          instances: NVIDIA(R) Tesla(R) drivers and NVIDIA(R) CUDA toolkit.""")
 
   google = parser.add_argument_group(
       title='"google" provider options',
@@ -370,24 +388,6 @@ def _parse_arguments(prog, argv):
           after a localization, docker command, or delocalization failure.
           Allows for connecting to the VM for debugging.
           Default is 0; maximum allowed value is 86400 (1 day).""")
-  google.add_argument(
-      '--accelerator-type',
-      help="""The Compute Engine accelerator type. By specifying this parameter,
-          you will download and install the following third-party software onto
-          your job's Compute Engine instances: NVIDIA(R) Tesla(R) drivers and
-          NVIDIA(R) CUDA toolkit. Please see
-          https://cloud.google.com/compute/docs/gpus/ for supported GPU types
-          and
-          https://cloud.google.com/genomics/reference/rest/v1alpha2/pipelines#pipelineresources
-          for more details.""")
-  google.add_argument(
-      '--accelerator-count',
-      type=int,
-      default=0,
-      help="""The number of accelerators of the specified type to attach.
-          By specifying this parameter, you will download and install the
-          following third-party software onto your job's Compute Engine
-          instances: NVIDIA(R) Tesla(R) drivers and NVIDIA(R) CUDA toolkit.""")
 
   google_v2 = parser.add_argument_group(
       title='"google-v2" provider options',

--- a/dsub/lib/dsub_errors.py
+++ b/dsub/lib/dsub_errors.py
@@ -17,10 +17,19 @@
 class JobError(Exception):
   """Exception containing error information of one or more jobs."""
 
-  def __init__(self, message, error_list):
+  def __init__(self, message, error_list, launched_job):
+    """Create a JobError to indicate something went wrong.
+
+    Args:
+        message: user-friendly message
+        error_list: what went wrong
+        launched_job: if the job is launched, but has errors in
+          "--wait"ing on the tasks.
+    """
     super(JobError, self).__init__(message)
     self.message = message
     self.error_list = error_list
+    self.launched_job = launched_job
 
 
 class PredecessorJobFailureError(JobError):

--- a/dsub/lib/providers_util.py
+++ b/dsub/lib/providers_util.py
@@ -198,3 +198,8 @@ def get_task_metadata(job_metadata, task_id):
   task_metadata['task-id'] = task_id
 
   return task_metadata
+
+
+def get_job_and_task_param(job_params, task_params, field):
+  """Returns a dict combining the field for job and task params."""
+  return job_params.get(field, set()) | task_params.get(field, set())

--- a/dsub/providers/base.py
+++ b/dsub/providers/base.py
@@ -203,7 +203,7 @@ class Task(object):
 
     'job-name', 'job-id', 'task-id', 'task-attempt', 'user-id', 'task-status',
     'error-message', 'create-time', 'start-time', 'end-time', 'inputs',
-    'outputs'
+    'outputs', 'events'
 
     The following are required by dstat:
     - status: The task status ('RUNNING', 'CANCELED', 'FAILED', 'SUCCESS')

--- a/dsub/providers/google.py
+++ b/dsub/providers/google.py
@@ -986,6 +986,22 @@ class GoogleOperation(base.Task):
           'instance-name': instance_name,
           'zone': instance_zone,
       }
+    elif field == 'events':
+      events = metadata.get('events', [])
+      value = []
+      for event in events:
+        event_value = {
+            'name':
+                event.get('description', ''),
+            'start-time':
+                google_base.parse_rfc3339_utc_string(event['startTime'])
+        }
+        if 'endTime' in event:
+          event_value['end-time'] = google_base.parse_rfc3339_utc_string(
+              event['endTime'])
+
+        value.append(event_value)
+
     else:
       raise ValueError('Unsupported field: "%s"' % field)
 

--- a/dsub/providers/google_base.py
+++ b/dsub/providers/google_base.py
@@ -316,7 +316,11 @@ def parse_rfc3339_utc_string(rfc3339_utc_string):
   else:
     assert False, 'Fraction length not 0, 6, or 9: {}'.len(fraction)
 
-  return datetime(g[0], g[1], g[2], g[3], g[4], g[5], micros, tzinfo=pytz.utc)
+  try:
+    return datetime(g[0], g[1], g[2], g[3], g[4], g[5], micros, tzinfo=pytz.utc)
+  except ValueError as e:
+    assert False, 'Could not parse RFC3339 datestring: {} exception: {}'.format(
+        rfc3339_utc_string, e)
 
 
 def get_operation_full_job_id(op):
@@ -478,6 +482,7 @@ def setup_service(api_name, api_version, credentials=None):
 
 
 class Api(object):
+  """Wrapper around API execution with exponential backoff retries."""
 
   # Exponential backoff retrying API execution.
   # Maximum 23 retries.  Wait 1, 2, 4 ... 64, 64, 64... seconds.

--- a/dsub/providers/google_base.py
+++ b/dsub/providers/google_base.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 # pylint: disable=g-tzinfo-datetime
 from datetime import datetime
+import json
 import os
 import re
 import socket
@@ -62,6 +63,15 @@ TRANSIENT_HTTP_ERROR_CODES = set([429, 500, 503, 504])
 
 # Socket error 104 (connection reset) should also be retried
 TRANSIENT_SOCKET_ERROR_CODES = set([104])
+
+# When attempting to cancel an operation that is already completed
+# (succeeded, failed, or canceled), the response will include:
+# "error": {
+#    "code": 400,
+#    "status": "FAILED_PRECONDITION",
+# }
+FAILED_PRECONDITION_CODE = 400
+FAILED_PRECONDITION_STATUS = 'FAILED_PRECONDITION'
 
 # List of Compute Engine zones, which enables simple wildcard expansion.
 # We could look this up dynamically, but new zones come online
@@ -307,6 +317,115 @@ def parse_rfc3339_utc_string(rfc3339_utc_string):
     assert False, 'Fraction length not 0, 6, or 9: {}'.len(fraction)
 
   return datetime(g[0], g[1], g[2], g[3], g[4], g[5], micros, tzinfo=pytz.utc)
+
+
+def get_operation_full_job_id(op):
+  """Returns the job-id or job-id.task-id for the operation."""
+  job_id = op.get_field('job-id')
+  task_id = op.get_field('task-id')
+  if task_id:
+    return '%s.%s' % (job_id, task_id)
+  else:
+    return job_id
+
+
+def _cancel_batch(batch_fn, cancel_fn, ops):
+  """Cancel a batch of operations.
+
+  Args:
+    batch_fn: API-specific batch function.
+    cancel_fn: API-specific cancel function.
+    ops: A list of operations to cancel.
+
+  Returns:
+    A list of operations canceled and a list of error messages.
+  """
+
+  # We define an inline callback which will populate a list of
+  # successfully canceled operations as well as a list of operations
+  # which were not successfully canceled.
+
+  canceled = []
+  failed = []
+
+  def handle_cancel_response(request_id, response, exception):
+    """Callback for the cancel response."""
+    del response  # unused
+
+    if exception:
+      # We don't generally expect any failures here, except possibly trying
+      # to cancel an operation that is already canceled or finished.
+      #
+      # If the operation is already finished, provide a clearer message than
+      # "error 400: Bad Request".
+
+      msg = 'error %s: %s' % (exception.resp.status, exception.resp.reason)
+      if exception.resp.status == FAILED_PRECONDITION_CODE:
+        detail = json.loads(exception.content)
+        status = detail.get('error', {}).get('status')
+        if status == FAILED_PRECONDITION_STATUS:
+          msg = 'Not running'
+
+      failed.append({'name': request_id, 'msg': msg})
+    else:
+      canceled.append({'name': request_id})
+
+    return
+
+  # Set up the batch object
+  batch = batch_fn(callback=handle_cancel_response)
+
+  # The callback gets a "request_id" which is the operation name.
+  # Build a dict such that after the callback, we can lookup the operation
+  # objects by name
+  ops_by_name = {}
+  for op in ops:
+    op_name = op.get_field('internal-id')
+    ops_by_name[op_name] = op
+    batch.add(cancel_fn(name=op_name, body={}), request_id=op_name)
+
+  # Cancel the operations
+  batch.execute()
+
+  # Iterate through the canceled and failed lists to build our return lists
+  canceled_ops = [ops_by_name[op['name']] for op in canceled]
+  error_messages = []
+  for fail in failed:
+    op = ops_by_name[fail['name']]
+    error_messages.append("Error canceling '%s': %s" %
+                          (get_operation_full_job_id(op), fail['msg']))
+
+  return canceled_ops, error_messages
+
+
+def cancel(batch_fn, cancel_fn, ops):
+  """Cancel operations.
+
+  Args:
+    batch_fn: API-specific batch function.
+    cancel_fn: API-specific cancel function.
+    ops: A list of operations to cancel.
+
+  Returns:
+    A list of operations canceled and a list of error messages.
+  """
+
+  # Canceling many operations one-by-one can be slow.
+  # The Pipelines API doesn't directly support a list of operations to cancel,
+  # but the requests can be performed in batch.
+
+  canceled_ops = []
+  error_messages = []
+
+  max_batch = 256
+  total_ops = len(ops)
+  for first_op in range(0, total_ops, max_batch):
+    batch_canceled, batch_messages = _cancel_batch(
+        batch_fn, cancel_fn, ops[first_op:first_op + max_batch])
+    canceled_ops.extend(batch_canceled)
+    error_messages.extend(batch_messages)
+
+  return canceled_ops, error_messages
 
 
 def retry_api_check(exception):

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -545,11 +545,16 @@ class GoogleV2JobProvider(base.JobProvider):
     assert len(actions) == final_logging_action
 
     disks = [
-        google_v2_pipelines.build_disks(_DATA_DISK_NAME,
-                                        job_resources.disk_size)
+        google_v2_pipelines.build_disk(_DATA_DISK_NAME, job_resources.disk_size)
     ]
     network = google_v2_pipelines.build_network(None, None)
     machine_type = job_resources.machine_type or job_model.DEFAULT_MACHINE_TYPE
+    accelerators = None
+    if job_resources.accelerator_type:
+      accelerators = [
+          google_v2_pipelines.build_accelerator(job_resources.accelerator_type,
+                                                job_resources.accelerator_count)
+      ]
     service_account = google_v2_pipelines.build_service_account(
         'default', scopes)
 
@@ -564,6 +569,7 @@ class GoogleV2JobProvider(base.JobProvider):
             service_account=service_account,
             boot_disk_size_gb=job_resources.boot_disk_size,
             disks=disks,
+            accelerators=accelerators,
             labels=labels),
     )
 

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -1057,6 +1057,10 @@ class GoogleOperation(base.Task):
               (d for d in vm['disks'] if d['name'] == _DATA_DISK_NAME))
           if datadisk:
             value['disk-size'] = datadisk['sizeGb']
+    elif field == 'events':
+      # TODO: Implement events for pipelines-v2. There are a ton
+      # of events in v2 so we'll likely need to filter some of them.
+      value = [{'name': 'TODO', 'start-time': None}]
     else:
       raise ValueError('Unsupported field: "%s"' % field)
 

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -1032,7 +1032,25 @@ class GoogleOperation(base.Task):
     elif field == 'provider':
       return _PROVIDER_NAME
     elif field == 'provider-attributes':
-      value = 'TODO'
+      # Unlike Pipelines API v1, the v2 API hides the VM, so just emit
+      # configured items, like region, zone, VM type.
+      value = {}
+      resources = google_v2_operations.get_resources(self._op)
+      if 'regions' in resources:
+        value['regions'] = resources['regions']
+      if 'zones' in resources:
+        value['zones'] = resources['zones']
+      if 'virtualMachine' in resources:
+        vm = resources['virtualMachine']
+        value['machine-type'] = vm['machineType']
+        value['preemptible'] = vm['preemptible']
+
+        value['boot-disk-size'] = vm['bootDiskSizeGb']
+        if 'disks' in vm:
+          datadisk = next(
+              (d for d in vm['disks'] if d['name'] == _DATA_DISK_NAME))
+          if datadisk:
+            value['disk-size'] = datadisk['sizeGb']
     else:
       raise ValueError('Unsupported field: "%s"' % field)
 

--- a/dsub/providers/google_v2_operations.py
+++ b/dsub/providers/google_v2_operations.py
@@ -141,6 +141,11 @@ def get_last_update(op):
   return last_update
 
 
+def get_resources(op):
+  """Return the operation's resource."""
+  return op.get('metadata', {}).get('pipeline').get('resources', {})
+
+
 def is_pipeline(op):
   """Check that an operation is a genomics pipeline run.
 

--- a/dsub/providers/google_v2_operations.py
+++ b/dsub/providers/google_v2_operations.py
@@ -84,7 +84,7 @@ def is_failed(op):
 
 
 def get_labels(op):
-  """Return the operations array of labels."""
+  """Return the operation's array of labels."""
   return op.get('metadata', {}).get('labels', {})
 
 
@@ -93,8 +93,28 @@ def get_label(op, name):
   return get_labels(op).get(name)
 
 
+def get_actions(op):
+  """Return the operation's array of actions."""
+  return op.get('metadata', {}).get('pipeline').get('actions', [])
+
+
+def get_action(op, name):
+  """Return the value for the specified action."""
+  actions = get_actions(op)
+  for action in actions:
+    if action['name'] == name:
+      return action
+
+
+def get_action_environment(op, name):
+  """Return the environment for the operation."""
+  action = get_action(op, name)
+  if action:
+    return action.get('environment')
+
+
 def get_events(op):
-  """Return the arry of events for the operation."""
+  """Return the array of events for the operation."""
   return op.get('metadata', {}).get('events', [])
 
 

--- a/dsub/providers/google_v2_pipelines.py
+++ b/dsub/providers/google_v2_pipelines.py
@@ -26,11 +26,15 @@ def build_network(name, use_private_address):
   }
 
 
-def build_disks(name, size_gb):
-  return [{
+def build_disk(name, size_gb):
+  return {
       'name': name,
       'sizeGb': size_gb,
-  }]
+  }
+
+
+def build_accelerator(accelerator_type, accelerator_count):
+  return {'type': accelerator_type, 'count': accelerator_count}
 
 
 def build_service_account(email, scopes):
@@ -46,6 +50,7 @@ def build_machine(network=None,
                   service_account=None,
                   boot_disk_size_gb=None,
                   disks=None,
+                  accelerators=None,
                   labels=None):
   """Build a VirtualMachine object for a Pipeline request.
 
@@ -56,6 +61,7 @@ def build_machine(network=None,
     service_account (dict): Service account configuration for the VM.
     boot_disk_size_gb (int): Boot disk size in GB.
     disks (list[dict]): List of disks to mount.
+    accelerators (list[dict]): List of accelerators to attach to the VM.
     labels (dict[string, string]): Labels for the VM.
 
   Returns:
@@ -68,6 +74,7 @@ def build_machine(network=None,
       'serviceAccount': service_account,
       'bootDiskSizeGb': boot_disk_size_gb,
       'disks': disks,
+      'accelerators': accelerators,
       'labels': labels,
   }
 

--- a/dsub/providers/local.py
+++ b/dsub/providers/local.py
@@ -881,9 +881,6 @@ class LocalTask(base.Task):
     """
     return self._raw._asdict()
 
-  def _get_job_and_task_param(self, job_params, task_params, field):
-    return job_params.get(field, set()) | task_params.get(field, set())
-
   def get_field(self, field, default=None):
 
     # Most fields should be satisfied from the job descriptor
@@ -913,17 +910,20 @@ class LocalTask(base.Task):
       # get_field('logging') should currently return the resolved logging path.
       value = task_resources.logging_path
     elif field in ['labels', 'envs']:
-      items = self._get_job_and_task_param(job_params, task_params, field)
+      items = providers_util.get_job_and_task_param(job_params, task_params,
+                                                    field)
       value = {item.name: item.value for item in items}
     elif field == 'inputs':
       value = {}
       for field in ['inputs', 'input-recursives']:
-        items = self._get_job_and_task_param(job_params, task_params, field)
+        items = providers_util.get_job_and_task_param(job_params, task_params,
+                                                      field)
         value.update({item.name: item.value for item in items})
     elif field == 'outputs':
       value = {}
       for field in ['outputs', 'output-recursives']:
-        items = self._get_job_and_task_param(job_params, task_params, field)
+        items = providers_util.get_job_and_task_param(job_params, task_params,
+                                                      field)
         value.update({item.name: item.value for item in items})
     elif field == 'provider':
       return _PROVIDER_NAME

--- a/dsub/providers/local.py
+++ b/dsub/providers/local.py
@@ -445,6 +445,8 @@ class LocalJobProvider(base.JobProvider):
       today = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
       with open(os.path.join(task_dir, 'status.txt'), 'wt') as f:
         f.write('CANCELED\n')
+      with open(os.path.join(task_dir, 'events.txt'), 'a') as f:
+        f.write('canceled,{}\n'.format(today))
       with open(os.path.join(task_dir, 'end-time.txt'), 'wt') as f:
         f.write(today)
       msg = 'Operation canceled at %s\n' % today
@@ -593,6 +595,21 @@ class LocalJobProvider(base.JobProvider):
         datetime.datetime.fromtimestamp(last_update),
         tzlocal()) if last_update > 0 else None
 
+  def _get_events_from_task_dir(self, task_dir):
+    try:
+      with open(os.path.join(task_dir, 'events.txt'), 'r') as f:
+        events = []
+        for line in f:
+          if line.rstrip():
+            name, time_string = line.split(',')
+            start_time = dsub_util.replace_timezone(
+                datetime.datetime.strptime(time_string.rstrip(),
+                                           '%Y-%m-%d %H:%M:%S.%f'), tzlocal())
+            events.append({'name': name, 'start-time': start_time})
+        return events
+    except (IOError, OSError):
+      return None
+
   def _get_status_from_task_dir(self, task_dir):
     try:
       with open(os.path.join(task_dir, 'status.txt'), 'r') as f:
@@ -642,6 +659,7 @@ class LocalJobProvider(base.JobProvider):
     # For new tasks, these may not have been written yet.
     end_time = self._get_end_time_from_task_dir(task_dir)
     last_update = self._get_last_update_time_from_task_dir(task_dir)
+    events = self._get_events_from_task_dir(task_dir)
     status = self._get_status_from_task_dir(task_dir)
     log_detail = self._get_log_detail_from_task_dir(task_dir)
 
@@ -652,6 +670,7 @@ class LocalJobProvider(base.JobProvider):
 
     return LocalTask(
         task_status=status,
+        events=events,
         log_detail=log_detail,
         job_descriptor=job_descriptor,
         end_time=end_time,
@@ -860,6 +879,7 @@ class LocalJobProvider(base.JobProvider):
 _RawTask = namedtuple('_RawTask', [
     'job_descriptor',
     'task_status',
+    'events',
     'log_detail',
     'end_time',
     'last_update',
@@ -929,6 +949,8 @@ class LocalTask(base.Task):
       return _PROVIDER_NAME
     elif field == 'provider-attributes':
       value = {}
+    elif field == 'events':
+      value = self._raw.events
     else:
       # Convert the raw Task object to a dict.
       # With the exception of the "status' fields, the dsub field names map

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
         'oauth2client',
         'python-dateutil',
         'pytz',
-        'pyyaml',
+        'pyyaml==3.12',
         'retrying',
         'tabulate',
 

--- a/test/integration/e2e_after_fail.sh
+++ b/test/integration/e2e_after_fail.sh
@@ -28,10 +28,13 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
 
   # (1) Launch a job to test command execution failure
   echo "Launch a job that should fail (--wait for it)..."
-  if run_dsub \
+  if JOBID="$(run_dsub \
       --command 'exit 1' \
-      --wait; then
+      --wait)"; then
     echo "Expected dsub to exit with error."
+    exit 1
+  elif [[ -z "${JOBID}" ]]; then
+    echo "dsub did not report a jobid but it should have."
     exit 1
   fi
 
@@ -42,11 +45,14 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
 
   # (3) This call to dsub should fail before submit
   echo "Launch a job that should fail (--after the previous)"
-  if run_dsub \
+  if JOBID="$(run_dsub \
       --command 'echo "does not matter"' \
       --after "${BAD_JOB_PREVIOUS}" \
-      --wait; then
+      --wait)"; then
     echo "Expected dsub to exit with error."
+    exit 1
+  elif [[ "${JOBID}" != "NO_JOB" ]]; then
+    echo "dsub reported JOBID: '${JOBID}', expected 'NO_JOB'"
     exit 1
   fi
 

--- a/test/integration/e2e_error.sh
+++ b/test/integration/e2e_error.sh
@@ -30,12 +30,34 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
 
   if run_dsub \
     --image 'ubuntu' \
+    --name 'e2e-error' \
     --command 'idontknowhowtounix' \
     --wait; then
     echo "dsub did not report the failure as it should have."
     exit 1
   fi
 
+  DSTAT_OUTPUT=$(run_dstat --status '*' --names e2e-error --full)
+
+  declare -a EXPECTED_EVENTS
+  if [[ "${DSUB_PROVIDER}" == "google" ]]; then
+    EXPECTED_EVENTS=(start pulling-image localizing-files running-docker fail)
+  elif [[ "${DSUB_PROVIDER}" == "local" ]]; then
+    # The local provider has slightly different events in this error case
+    EXPECTED_EVENTS=(start pulling-image localizing-files running-docker delocalizing-files fail)
+  else
+    # TODO: Update once events are implemented for google-v2
+    EXPECTED_EVENTS=(TODO)
+  fi
+
+  for ((i = 0 ; i < "${#EXPECTED_EVENTS[@]}"; i++)); do
+    EXPECTED="${EXPECTED_EVENTS[i]}"
+    ACTUAL="$(python "${SCRIPT_DIR}"/get_data_value.py "yaml" "${DSTAT_OUTPUT}" "[0].events.[${i}].name")"
+    if [[ ${ACTUAL} != ${EXPECTED} ]]; then
+      echo "Job e2e-error has incorrect event (${i}): ${ACTUAL} should be: ${EXPECTED}"
+      exit 1
+    fi
+  done
 fi
 
 echo "SUCCESS"

--- a/test/integration/test_setup.sh
+++ b/test/integration/test_setup.sh
@@ -186,6 +186,13 @@ function ddel_google() {
     "${@}"
 }
 
+function ddel_google-v2() {
+  ddel \
+    --provider google-v2 \
+    --project "${PROJECT_ID}" \
+    "${@}"
+}
+
 function ddel_local() {
   ddel \
     --provider local \

--- a/test/integration/unit_flags.google-v2.sh
+++ b/test/integration/unit_flags.google-v2.sh
@@ -70,7 +70,7 @@ function test_with_region_and_zone() {
     --zones us-central1-f \
     --regions us-central1; then
 
-    2>&1 echo "Neither regions nor zones specified - not detected"
+    2>&1 echo "Both regions and zones specified - not detected"
 
     test_failed "${subtest}"
   else
@@ -85,6 +85,46 @@ function test_with_region_and_zone() {
 }
 readonly -f test_with_region_and_zone
 
+function test_accelerator_type_and_count() {
+  local subtest="${FUNCNAME[0]}"
+
+  if call_dsub \
+    --command 'echo "${TEST_NAME}"' \
+    --regions us-central1 \
+    --accelerator-type "nvidia-tesla-k80" \
+    --accelerator-count 2; then
+
+    # Check that the output contains expected values
+    assert_err_value_equals \
+     "[0].pipeline.resources.virtualMachine.accelerators.[0].type" "nvidia-tesla-k80"
+    assert_err_value_equals \
+     "[0].pipeline.resources.virtualMachine.accelerators.[0].count" "2"
+
+    test_passed "${subtest}"
+  else
+    test_failed "${subtest}"
+  fi
+}
+readonly -f test_accelerator_type_and_count
+
+function test_no_accelerator_type_and_count() {
+  local subtest="${FUNCNAME[0]}"
+
+  if call_dsub \
+    --command 'echo "${TEST_NAME}"' \
+    --regions us-central1; then
+
+    # Check that the output contains expected values
+    assert_err_value_equals \
+     "[0].pipeline.resources.virtualMachine.accelerators" "None"
+
+    test_passed "${subtest}"
+  else
+    test_failed "${subtest}"
+  fi
+}
+readonly -f test_no_accelerator_type_and_count
+
 # Run the tests
 trap "exit_handler" EXIT
 
@@ -93,3 +133,7 @@ mkdir -p "${TEST_TMP}"
 echo
 test_with_neither_region_nor_zone
 test_with_region_and_zone
+
+echo
+test_accelerator_type_and_count
+test_no_accelerator_type_and_count

--- a/test/integration/unit_flags.google.sh
+++ b/test/integration/unit_flags.google.sh
@@ -249,7 +249,7 @@ function test_accelerator_type_and_count() {
     test_failed "${subtest}"
   fi
 }
-readonly -f test_no_keep_alive
+readonly -f test_accelerator_type_and_count
 
 function test_no_accelerator_type_and_count() {
   local subtest="${FUNCNAME[0]}"
@@ -270,7 +270,7 @@ function test_no_accelerator_type_and_count() {
     test_failed "${subtest}"
   fi
 }
-readonly -f test_no_keep_alive
+readonly -f test_no_accelerator_type_and_count
 
 # Run the tests
 trap "exit_handler" EXIT

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -216,11 +216,6 @@ function get_test_providers() {
   fi
 
   case "${test_file}" in
-    e2e_io.sh | \
-    e2e_io_gcs_tasks.sh | \
-    e2e_io_tasks.sh | \
-    e2e_logging_paths_tasks.sh | \
-    e2e_logging_paths.sh | \
     e2e_non_root.sh)
       local all_provider_list="${DSUB_PROVIDER:-local google}"
       ;;

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -215,7 +215,20 @@ function get_test_providers() {
     return
   fi
 
-  local all_provider_list="${DSUB_PROVIDER:-local google}"
+  case "${test_file}" in
+    e2e_io.sh | \
+    e2e_io_gcs_tasks.sh | \
+    e2e_io_tasks.sh | \
+    e2e_logging_paths_tasks.sh | \
+    e2e_logging_paths.sh | \
+    e2e_non_root.sh)
+      local all_provider_list="${DSUB_PROVIDER:-local google}"
+      ;;
+    *)
+      local all_provider_list="${DSUB_PROVIDER:-local google google-v2}"
+      ;;
+  esac
+
   echo -n "${all_provider_list}"
 }
 readonly -f get_test_providers

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -215,15 +215,7 @@ function get_test_providers() {
     return
   fi
 
-  case "${test_file}" in
-    e2e_non_root.sh)
-      local all_provider_list="${DSUB_PROVIDER:-local google}"
-      ;;
-    *)
-      local all_provider_list="${DSUB_PROVIDER:-local google google-v2}"
-      ;;
-  esac
-
+  local all_provider_list="${DSUB_PROVIDER:-local google google-v2}"
   echo -n "${all_provider_list}"
 }
 readonly -f get_test_providers

--- a/test/unit/local_provider_test.py
+++ b/test/unit/local_provider_test.py
@@ -56,7 +56,7 @@ def _make_task(job_create_time, task_create_time, task_id):
       end_time=None,
       last_update=None,
       pid=None,
-  )
+      events=None)
 
 
 CREATE_TIME_1 = dsub_util.replace_timezone(


### PR DESCRIPTION
All unit and integration tests now pass for the `google-v2` provider.
Users interested in [Google's Pipelines v2](https://cloud.google.com/genomics/reference/rest/v2alpha1/pipelines) are encouraged to give it a try.

This pull request includes includes:

* `google-v2` provider:
  * `dstat` fields such as `envs`, `inputs`, `outputs`, and `logging` now supported.
  * `ddel` supported

* General
  * `dsub` returns task-id even if failure is detected when using `--wait`.
  * `events` included in `dstat` output (`local` and `google` providers)
