### PR TITLE
Creates the argument min-cpu-platform for the google-v2 provider

### DIFF
--- a/dsub/commands/dsub.py
+++ b/dsub/commands/dsub.py
@@ -399,6 +399,8 @@ def _parse_arguments(prog, argv):
           Only one of --zones and --regions may be specified.""")
   google_v2.add_argument(
       '--machine-type', help='Provider-specific machine type')
+  google_v2.add_argument(
+      '--min-cpu-platform', help='Provider-specific minimum CPU platform')
 
   args = provider_base.parse_args(
       parser, {
@@ -430,6 +432,7 @@ def _get_job_resources(args):
       min_cores=args.min_cores,
       min_ram=args.min_ram,
       machine_type=args.machine_type,
+      min_cpu_platform=args.min_cpu_platform,
       disk_size=args.disk_size,
       boot_disk_size=args.boot_disk_size,
       preemptible=args.preemptible,

--- a/dsub/lib/job_model.py
+++ b/dsub/lib/job_model.py
@@ -324,7 +324,7 @@ class OutputFileParam(FileParam):
 
 class Resources(
     collections.namedtuple('Resources', [
-        'min_cores', 'min_ram', 'machine_type', 'disk_size', 'boot_disk_size',
+        'min_cores', 'min_ram', 'machine_type', 'min_cpu_platform', 'disk_size', 'boot_disk_size',
         'preemptible', 'image', 'logging', 'logging_path', 'regions', 'zones',
         'scopes', 'keep_alive', 'accelerator_type', 'accelerator_count'
     ])):
@@ -334,6 +334,7 @@ class Resources(
     min_cores (int): number of CPU cores
     min_ram (float): amount of memory (in GB)
     machine_type (str): machine type (e.g. 'n1-standard-1', 'custom-1-4096')
+    min_cpu_platform (str): lowest permitted CPU platform (e.g., 'Intel Skylake')
     disk_size (int): size of the data disk (in GB)
     boot_disk_size (int): size of the boot disk (in GB)
     preemptible (bool): use a preemptible VM for the job
@@ -354,6 +355,7 @@ class Resources(
               min_cores=None,
               min_ram=None,
               machine_type=None,
+              min_cpu_platform=None,
               disk_size=None,
               boot_disk_size=None,
               preemptible=None,
@@ -367,7 +369,7 @@ class Resources(
               accelerator_type=None,
               accelerator_count=0):
     return super(Resources, cls).__new__(
-        cls, min_cores, min_ram, machine_type, disk_size, boot_disk_size,
+        cls, min_cores, min_ram, machine_type, min_cpu_platform, disk_size, boot_disk_size,
         preemptible, image, logging, logging_path, regions, zones, scopes,
         keep_alive, accelerator_type, accelerator_count)
 

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -549,6 +549,7 @@ class GoogleV2JobProvider(base.JobProvider):
     ]
     network = google_v2_pipelines.build_network(None, None)
     machine_type = job_resources.machine_type or job_model.DEFAULT_MACHINE_TYPE
+    min_cpu_platform = job_resources.min_cpu_platform
     accelerators = None
     if job_resources.accelerator_type:
       accelerators = [
@@ -565,6 +566,7 @@ class GoogleV2JobProvider(base.JobProvider):
         google_v2_pipelines.build_machine(
             network=network,
             machine_type=machine_type,
+            min_cpu_platform=min_cpu_platform,
             preemptible=job_resources.preemptible,
             service_account=service_account,
             boot_disk_size_gb=job_resources.boot_disk_size,
@@ -1049,6 +1051,7 @@ class GoogleOperation(base.Task):
       if 'virtualMachine' in resources:
         vm = resources['virtualMachine']
         value['machine-type'] = vm['machineType']
+        value['min-cpu-platform'] = vm['cpuPlatform']
         value['preemptible'] = vm['preemptible']
 
         value['boot-disk-size'] = vm['bootDiskSizeGb']

--- a/dsub/providers/google_v2_pipelines.py
+++ b/dsub/providers/google_v2_pipelines.py
@@ -46,6 +46,7 @@ def build_service_account(email, scopes):
 
 def build_machine(network=None,
                   machine_type=None,
+                  min_cpu_platform=None,
                   preemptible=None,
                   service_account=None,
                   boot_disk_size_gb=None,
@@ -57,6 +58,7 @@ def build_machine(network=None,
   Args:
     network (dict): Network details for the pipeline to run in.
     machine_type (str): GCE Machine Type string for the pipeline.
+    min_cpu_platform (str): GCE Minimum CPU platform (e.g. "Intel Skylake").
     preemptible (bool): Use a preemptible VM for the job.
     service_account (dict): Service account configuration for the VM.
     boot_disk_size_gb (int): Boot disk size in GB.
@@ -70,6 +72,7 @@ def build_machine(network=None,
   return {
       'network': network,
       'machineType': machine_type,
+      'cpuPlatform': min_cpu_platform,
       'preemptible': preemptible,
       'serviceAccount': service_account,
       'bootDiskSizeGb': boot_disk_size_gb,


### PR DESCRIPTION
Creates the argument `min-cpu-platform` for the google-v2 provider. This permits the specification of a CPU Platform such as, e.g., "Intel Skylake", which is required for certain instruction sets such as AVX2, and for certain machine types (such as any machine that has more than 64 cores). This also resolves Issue #117 