### PR TITLE
PR for 0.2.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,34 @@ To copy folders rather than files, use the `--input-recursive` or
         --input-recursive FOLDER=gs://my-bucket/my-folder \
         --command 'find ${FOLDER} -name "foo*"'
 
+#### Mounting buckets
+
+The `google-v2` provider supports mounting a Cloud Storage bucket using
+[Cloud Storage FUSE](https://cloud.google.com/storage/docs/gcs-fuse). This
+capability is currently experimental, but may be most useful when:
+
+1. You have a large input file in Cloud Storage over which your code makes
+a single read pass or only needs to read a small range of bytes.
+2. You have a large set of resource files in Cloud Storage, your code only reads
+a subset of those files, and the decision of which files to read is determined
+at runtime.
+
+Writing to a mounted bucket is not recommended.
+
+Please read
+[Key differences from a POSIX file system](https://cloud.google.com/storage/docs/gcs-fuse#notes)
+and [Semantics](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/docs/semantics.md)
+before using Cloud Storage FUSE.
+
+To mount a Cloud Storage bucket with the `google-v2` provider, use the `--mount`
+command line flag:
+
+    --mount MYBUCKET=gs://mybucket
+
+The bucket will be mounted to a local path given by the environment variable
+`${MYBUCKET}`. Inside your script, you can reference the local path using the
+environment variable.
+
 ##### Notice
 
 For the `google` provider, as a getting started convenience, if

--- a/docs/code.md
+++ b/docs/code.md
@@ -36,13 +36,11 @@ a simple file rewrite operation using
 
 **Be sure to enclose your `command string` in single quotes and not double
 quotes. If you use double quotes, the command will be expanded in your local
-shell before being passed to dsub. If your command flag was in double quotes
+shell before being passed to `dsub`. If your command flag was in double quotes
 as:**
 
     dsub \
-        --project my-cloud-project \
-        --zones "us-central1-*" \
-        --logging gs://my-bucket/logs \
+        ... \
         --env MESSAGE=hello \
         --command "echo ${MESSAGE}"
 

--- a/docs/job_control.md
+++ b/docs/job_control.md
@@ -61,35 +61,35 @@ dsub ... --after "${JOB_A}" "${JOB_B}"
 Here is the output of a sample run:
 
 ```
-$ JOBID_A=$(dsub --project "${MYPROJECT}" --zones "us-central1-*" \
+$ JOBID_A=$(dsub --provider google-v2 --project "${MYPROJECT}" --regions us-central1 \
 --logging "gs://${MYBUCKET}/logging/"   \
 --command 'echo "hello from job A"')
-Job: echo--<userid>--170328-093205-80
-Launched job-id: echo--<userid>--170328-093205-80
+Job: echo--<user>--180924-112256-64
+Launched job-id: echo--<user>--180924-112256-64
 To check the status, run:
-  dstat --project test-project --jobs echo--<userid>--170328-093205-80
+  dstat --provider google-v2 --project ${MYPROJECT} --jobs 'echo--<user>--180924-112256-64' --status '*'
 To cancel the job, run:
-  ddel --project test-project --jobs echo--<userid>--170328-093205-80
+  ddel --provider google-v2 --project ${MYPROJECT} --jobs 'echo--<user>--180924-112256-64'
 
 $ echo "${JOBID_A}"
-echo--<userid>--170328-093205-80
+echo--<user>--180924-112256-64
 
 $ JOBID_B=... (similar)
 
-$ JOBID_C=$(dsub --project "${MYPROJECT}" --zones "us-central1-*" \
+$ JOBID_C=$(dsub --provider google-v2 --project "${MYPROJECT}" --regions us-central1 \
 --logging "gs://${MYBUCKET}/logging/"   \
 --command 'echo "job C"' --after "${JOBID_A}" "${JOBID_B}")
-Job: echo--<userid>--170328-093415-23
 Waiting for predecessor jobs to complete...
-Waiting for: echo--<userid>--170328-093358-55, echo--<userid>--170328-093205-80.
-  echo--<userid>--170328-093205-80: ('Success', '2017-03-28 09:32:58')
-Waiting for: echo--<userid>--170328-093358-55.
-  echo--<userid>--170328-093358-55: ('Success', '2017-03-28 09:35:00')
-Launched job-id: echo--<userid>--170328-093415-23
+Waiting for: echo--<user>--180924-112256-64, echo--<user>--180924-112259-48.
+  echo--<user>--180924-112256-64: SUCCESS
+Waiting for: echo--<user>--180924-112259-48.
+  echo--<user>--180924-112259-48: SUCCESS
+Launched job-id: echo--<user>--180924-112302-87
 To check the status, run:
-  dstat --project test-project --jobs echo--<userid>--170328-093415-23
+  dstat --provider google-v2 --project ${MYPROJECT} --jobs 'echo--<user>--180924-112302-87' --status '*'
 To cancel the job, run:
-  ddel --project test-project --jobs echo--<userid>--170328-093415-23
+  ddel --provider google-v2 --project ${MYPROJECT} --jobs 'echo--<user>--180924-112302-87'
+echo--<user>--180924-112302-87
 ```
 
 ## --after is blocking

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -353,3 +353,41 @@ The Google Pipelines API is currently the only backend provider.
 See the
 [Pipelines API Troubleshooting guide](https://cloud.google.com/genomics/v1alpha2/pipelines-api-troubleshooting)
 for more details on log files.
+
+## SSH to the VM
+
+With the `google-v2` provider, there is no SSH server running on the
+Compute Engine Virtual Machine by default. To start an SSH server, use the
+`dsub` command-line flag `--ssh` , which will start an SSH container in the
+background and will mount your data disk. This will allow you to inspect the
+runtime environment of your job's container in real time.
+
+The SSH container will pick up authentication information from the VM, so to
+connect you can use the `gcloud compute ssh` command to establish an SSH
+session.
+
+The VM `instance-name` and `zone` can be found in the `provider-attributes`
+section of `dstat ... --full` output. For example:
+
+```
+  provider-attributes:
+    boot-disk-size: 10
+    disk-size: 200
+    instance-name: google-pipelines-worker-<hash>
+    machine-type: n1-standard-1
+    preemptible: false
+    regions:
+    - us-central1
+    zone: us-central1-f
+    zones: []
+```
+
+Then issue the command:
+
+```
+    gcloud compute \
+      --project your-project \
+      ssh \
+      --zone <zone> \
+     <instance-name>
+```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,8 +10,8 @@ filtering of output based on 3 fields. Each field can take a list of values
 to filter on:
 
 * `job-id`: one or more job-id values
-* `user-id`: the `$USER` who submitted the job, or `"*"` for all users
-* `status`: `RUNNING`, `SUCCESS`, `FAILURE`, `CANCELED`, or `"*"` for all job
+* `user-id`: the `$USER` who submitted the job, or `'*'` for all users
+* `status`: `RUNNING`, `SUCCESS`, `FAILURE`, `CANCELED`, or `'*'` for all job
 statuses
 
 ### Check all my running jobs
@@ -20,7 +20,7 @@ When submitted with no filter arguments, `dstat` shows  information for all
 tasks in the `RUNNING` state belonging to the current user:
 
 ```
-$ dstat --project my-project
+$ dstat --provider google-v2 --project my-project
 Job Name        Task    Status            Last Update
 --------------  ------  ----------------  -------------------
 my-job-name     task-3  localizing-files  2017-04-06 16:03:34
@@ -44,7 +44,7 @@ them separately. To check on a specific job, pass the `--jobs` (or `-j`)
 flag. For example:
 
 ```
-$ dstat --project my-project --jobs my-job-id
+$ dstat --provider google-v2 --project my-project --jobs my-job-id
 Job Name        Status    Last Update
 --------------  --------  -------------------
 my-job-name     Pending   2017-04-11 16:05:35
@@ -58,9 +58,11 @@ To check a specific job independent of status, pass the
 value `*` to `dstat`:
 
 ```
-$ dstat --project my-project \
+$ dstat \
+  --provider google-v2 \
+  --project my-project \
   --jobs my-job-id \
-  --status "*"
+  --status '*'
 Job Name        Status                          Last Update
 --------------  ------------------------------  -------------------
 my-job-name     Operation canceled at 2017-...  2017-04-11 16:07:02
@@ -73,7 +75,7 @@ Be sure to quote the `*` to prevent shell expansion.
 To view results for all jobs associated with your user id:
 
 ```
-dstat --project my-project --status "*"
+dstat --provider google-v2 --project my-project --status '*'
 ```
 
 ### Check jobs with my own labels
@@ -87,8 +89,8 @@ You can set labels on your job using the `--label` flag. For example:
 
 ```
 dsub \
-  --label "billing-code=c9" \
-  --label "batch=august-2017" \
+  --label 'billing-code=c9' \
+  --label 'batch=august-2017' \
   ...
 ```
 
@@ -109,9 +111,9 @@ For example, looking up all tasks from the above `--tasks` example:
 
 ```
 dstat \
-  --label "billing-code=a9" \
-  --label "batch=august-2017" \
-  --status "*" \
+  --label 'billing-code=a9' \
+  --label 'batch=august-2017' \
+  --status '*' \
   ...
 ```
 
@@ -119,10 +121,10 @@ Will match all jobs with the `billing-code` label of `a9`, while:
 
 ```
 dstat \
-  --label "billing-code=999" \
-  --label "batch=august-2017" \
-  --label "sample-id=sam002" \
-  --status "*" \
+  --label 'billing-code=999' \
+  --label 'batch=august-2017' \
+  --label 'sample-id=sam002' \
+  --status '*' \
   ...
 ```
 
@@ -136,9 +138,9 @@ To delete all of the above tasks:
 
 ```
 ddel \
-  --label "billing-code=a9" \
-  --label "batch=august-2017" \
-  --status "*" \
+  --label 'billing-code=a9' \
+  --label 'batch=august-2017' \
+  --status '*' \
   ...
 ```
 
@@ -146,10 +148,10 @@ To delete only the second task:
 
 ```
 dstat \
-  --label "billing-code=a9" \
-  --label "batch=august-2017" \
-  --label "sample-id=sam002" \
-  --status "*" \
+  --label 'billing-code=a9' \
+  --label 'batch=august-2017' \
+  --label 'sample-id=sam002' \
+  --status '*' \
   ...
 ```
 
@@ -174,7 +176,7 @@ use the `--age` flag.
 For example, the following command will return all jobs started in the last day:
 
 ```
-./dstat --project my-project --status "*" --age 1d
+./dstat --provider google-v2 --project my-project --status '*' --age 1d
 ```
 
 The `--age` flags supports the following types of values:
@@ -215,7 +217,9 @@ By default `dstat` will query job status and exit. However, you can use the
 The following examples shows minute-by-minute progression of 3 tasks
 
 ```
-$ dstat --project my-project \
+$ dstat \
+  --provider google-v2 \
+  --project my-project \
   --jobs my-job-id \
   --wait --poll-interval 60
 Job Name        Task    Status    Last Update
@@ -276,28 +280,15 @@ maintain consistency between dsub versions.
 ### Full output (default format YAML)
 
 ```
-$ dstat --project my-project \
+$ dstat \
+  --provider google-v2 \
+  --project my-project \
   --jobs my-job-id \
   --full
 - create-time: '2017-04-11 16:47:06'
   end-time: '2017-04-11 16:51:38'
   inputs:
     INPUT_PATH: gs://genomics-public-data/ftp-trace.ncbi.nih.gov/1000genomes/ftp/technical/pilot2_high_cov_GRCh37_bams/data/NA12878/alignment/NA12878.chrom9.SOLID.bfast.CEU.high_coverage.20100125.bam
-    _SCRIPT: |+
-      #!/bin/bash
-
-      # Copyright 2016 Google Inc. All Rights Reserved.
-      #
-      # Licensed under the Apache License, Version 2.0 (the "License");
-<trimmed for brevity>
-      readonly INPUT_FILE_LIST="$(ls "${INPUT_PATH}")"
-
-      for INPUT_FILE in "${INPUT_FILE_LIST[@]}"; do
-        FILE_NAME="$(basename "${INPUT_FILE}")"
-
-        md5sum "${INPUT_FILE}" | awk '{ print $1 }' > "${OUTPUT_DIR}/${FILE_NAME}.md5"
-      done
-
   internal-id: operations/OPERATION-ID
   job-id: my-job-id
   job-name: my-job-name
@@ -314,28 +305,23 @@ Note the `Internal ID` in this example provides the
 ### Full output as tabular text
 
 ```
-$ dstat --project my-project \
+$ dstat \
+  --provider google-v2 \
+  --project my-project \
   --jobs my-job-id \
   --format text \
   --full
 Job ID                                  Job Name        Status    Last Update          Created              Ended                User      Internal ID                                                         Inputs                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  Outputs
 --------------------------------------  --------------  --------  -------------------  -------------------  -------------------  --------  ------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  -------------------------------------------------------
-my-job-id                               my-job-name     Success   2017-04-11 16:51:38  2017-04-11 16:47:06  2017-04-11 16:51:38  my-user   operations/OPERATION-ID                                             INPUT_PATH=gs://genomics-public-data/ftp-trace.ncbi.nih.gov/1000genomes/ftp/technical/pilot2_high_cov_GRCh37_bams/data/NA12878/alignment/NA12878.chrom9.SOLID.bfast.CEU.high_coverage.20100125.bam, _SCRIPT=#!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-<trimmed for brevity>
-for INPUT_FILE in "${INPUT_FILE_LIST[@]}"; do
-  FILE_NAME="$(basename "${INPUT_FILE}")"
-
-  md5sum "${INPUT_FILE}" | awk '{ print $1 }' > "${OUTPUT_DIR}/${FILE_NAME}.md5"
-done  OUTPUT_PATH=gs://my-bucket/path/output
+my-job-id                               my-job-name     Success   2017-04-11 16:51:38  2017-04-11 16:47:06  2017-04-11 16:51:38  my-user   operations/OPERATION-ID                                             INPUT_PATH=gs://genomics-public-data/ftp-trace.ncbi.nih.gov/1000genomes/ftp/technical/pilot2_high_cov_GRCh37_bams/data/NA12878/alignment/NA12878.chrom9.SOLID.bfast.CEU.high_coverage.20100125.bam
 ```
 
 ### Full output as JSON
 
 ```
-$ dstat --project my-project \
+$ dstat \
+  --provider google-v2 \
+  --project my-project \
   --jobs my-job-id \
   --format json \
   --full
@@ -343,7 +329,6 @@ $ dstat --project my-project \
   {
     "status": "Success",
     "inputs": {
-      "_SCRIPT": "#!/bin/bash\n\n# Copyright 2016 Google Inc. All Rights Reserved.\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n<trimmed for brevity>for INPUT_FILE in \"${INPUT_FILE_LIST[@]}\"; do\n  FILE_NAME=\"$(basename \"${INPUT_FILE}\")\"\n\n  md5sum \"${INPUT_FILE}\" | awk '{ print $1 }' > \"${OUTPUT_DIR}/${FILE_NAME}.md5\"\ndone\n\n", 
       "INPUT_PATH": "gs://genomics-public-data/ftp-trace.ncbi.nih.gov/1000genomes/ftp/technical/pilot2_high_cov_GRCh37_bams/data/NA12878/alignment/NA12878.chrom9.SOLID.bfast.CEU.high_coverage.20100125.bam"
     },
     "job-name": "my-job-name",

--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.2.0'
+DSUB_VERSION = '0.2.1.dev0'

--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.2.1.dev0'
+DSUB_VERSION = '0.2.1'

--- a/dsub/commands/dstat.py
+++ b/dsub/commands/dstat.py
@@ -207,7 +207,15 @@ class JsonOutput(OutputFormatter):
     return field
 
   def print_table(self, table):
-    print(json.dumps(table, indent=2, default=self.serialize))
+    # Prior to Python 3.4, json.dumps() with an indent included
+    # trailing whitespace (see https://bugs.python.org/issue16333).
+    separators_to_eliminate_trailing_whitespace = (',', ': ')
+    print(
+        json.dumps(
+            table,
+            indent=2,
+            default=self.serialize,
+            separators=separators_to_eliminate_trailing_whitespace))
 
 
 def _prepare_summary_table(rows):

--- a/dsub/commands/dstat.py
+++ b/dsub/commands/dstat.py
@@ -143,8 +143,9 @@ class TextOutput(OutputFormatter):
         ('labels', 'Labels', self.format_pairs),
         ('inputs', 'Inputs', self.format_pairs),
         ('outputs', 'Outputs', self.format_pairs),
+        ('mounts', 'Mounts', self.format_pairs),
         ('dsub-version', 'Version'),
-        # These fielsd only shows up when summarizing
+        # These fields only shows up when summarizing
         ('status', 'Status'),
         ('task-count', 'Task Count'),
     ]
@@ -291,10 +292,11 @@ def _prepare_row(task, full, summary):
       row_spec('end-time', True, None),
       row_spec('internal-id', True, None),
       row_spec('logging', True, None),
+      row_spec('labels', True, {}),
+      row_spec('envs', True, {}),
       row_spec('inputs', True, {}),
       row_spec('outputs', True, {}),
-      row_spec('envs', True, {}),
-      row_spec('labels', True, {}),
+      row_spec('mounts', True, {}),
       row_spec('provider', True, None),
       row_spec('provider-attributes', True, {}),
       row_spec('events', True, []),

--- a/dsub/commands/dsub.py
+++ b/dsub/commands/dsub.py
@@ -112,6 +112,7 @@ SLEEP_FUNCTION = time.sleep  # so we can replace it in tests
 
 DEFAULT_INPUT_LOCAL_PATH = 'input'
 DEFAULT_OUTPUT_LOCAL_PATH = 'output'
+DEFAULT_MOUNT_LOCAL_PATH = 'mount'
 
 
 class TaskParamAction(argparse.Action):
@@ -463,6 +464,14 @@ def _parse_arguments(prog, argv):
       action='store_true',
       help="""If set to true, start an ssh container in the background
           to allow you to log in using SSH and debug in real time.""")
+  google_v2.add_argument(
+      '--mount',
+      nargs='*',
+      action=param_util.ListParamAction,
+      default=[],
+      help="""Google Cloud Storage bucket path (gs://bucket) to mount using
+          Cloud Storage FUSE (gcsfuse).""",
+      metavar='KEY=REMOTE_PATH')
 
   args = provider_base.parse_args(
       parser, {
@@ -928,12 +937,13 @@ def run_main(args):
       DEFAULT_INPUT_LOCAL_PATH)
   output_file_param_util = param_util.OutputFileParamUtil(
       DEFAULT_OUTPUT_LOCAL_PATH)
+  mount_param_util = param_util.MountParamUtil(DEFAULT_MOUNT_LOCAL_PATH)
 
   # Get job arguments from the command line
   job_params = param_util.args_to_job_params(
       args.env, args.label, args.input, args.input_recursive, args.output,
-      args.output_recursive, input_file_param_util, output_file_param_util)
-
+      args.output_recursive, args.mount, input_file_param_util,
+      output_file_param_util, mount_param_util)
   # If --tasks is on the command-line, then get task-specific data
   if args.tasks:
     task_descriptors = param_util.tasks_file_to_task_descriptors(

--- a/dsub/commands/dsub.py
+++ b/dsub/commands/dsub.py
@@ -457,6 +457,12 @@ def _parse_arguments(prog, argv):
           Time can be listed using a number followed by a unit. Supported units
           are s (seconds), m (minutes), h (hours).
           Example: '5m' (5 minutes). Default is '1m'.""")
+  google_v2.add_argument(
+      '--ssh',
+      default=False,
+      action='store_true',
+      help="""If set to true, start an ssh container in the background
+          to allow you to log in using SSH and debug in real time.""")
 
   args = provider_base.parse_args(
       parser, {
@@ -509,7 +515,8 @@ def _get_job_resources(args):
       accelerator_type=args.accelerator_type,
       accelerator_count=args.accelerator_count,
       timeout=timeout,
-      log_interval=log_interval)
+      log_interval=log_interval,
+      ssh=args.ssh)
 
 
 def _get_job_metadata(provider, user_id, job_name, script, task_ids):

--- a/dsub/commands/dsub.py
+++ b/dsub/commands/dsub.py
@@ -447,9 +447,16 @@ def _parse_arguments(prog, argv):
       '--timeout',
       help="""The maximum amount of time to give the pipeline to complete.
           This includes the time spent waiting for a worker to be allocated.
-          Time can be listed using a number followed by a unit. Supported units are
-          s (seconds), m (minutes), h (hours), d (days), w (weeks).
-          For example: '7d' (7 days).""")
+          Time can be listed using a number followed by a unit. Supported units
+          are s (seconds), m (minutes), h (hours), d (days), w (weeks).
+          Example: '7d' (7 days).""")
+  google_v2.add_argument(
+      '--log-interval',
+      help="""The amount of time to sleep between copies of log files from
+          the pipeline to the logging path.
+          Time can be listed using a number followed by a unit. Supported units
+          are s (seconds), m (minutes), h (hours).
+          Example: '5m' (5 minutes). Default is '1m'.""")
 
   args = provider_base.parse_args(
       parser, {
@@ -479,6 +486,7 @@ def _get_job_resources(args):
   logging = param_util.build_logging_param(
       args.logging) if args.logging else None
   timeout = param_util.timeout_in_seconds(args.timeout)
+  log_interval = param_util.log_interval_in_seconds(args.log_interval)
 
   return job_model.Resources(
       min_cores=args.min_cores,
@@ -500,7 +508,8 @@ def _get_job_resources(args):
       use_private_address=args.use_private_address,
       accelerator_type=args.accelerator_type,
       accelerator_count=args.accelerator_count,
-      timeout=timeout)
+      timeout=timeout,
+      log_interval=log_interval)
 
 
 def _get_job_metadata(provider, user_id, job_name, script, task_ids):

--- a/dsub/lib/job_model.py
+++ b/dsub/lib/job_model.py
@@ -328,7 +328,7 @@ class Resources(
         'preemptible', 'image', 'logging', 'logging_path', 'regions', 'zones',
         'scopes', 'keep_alive', 'cpu_platform', 'network', 'subnetwork',
         'use_private_address', 'accelerator_type', 'accelerator_count',
-        'timeout'
+        'timeout', 'log_interval'
     ])):
   """Job resource parameters related to CPUs, memory, and disk.
 
@@ -354,6 +354,7 @@ class Resources(
     accelerator_count (int): Number of accelerators of the specified type to
       attach.
     timeout (string): The max amount of time to give the pipeline to complete.
+    log_interval (string): The amount of time to sleep between log uploads.
   """
   __slots__ = ()
 
@@ -377,12 +378,13 @@ class Resources(
               use_private_address=None,
               accelerator_type=None,
               accelerator_count=0,
-              timeout=None):
+              timeout=None,
+              log_interval=None):
     return super(Resources, cls).__new__(
         cls, min_cores, min_ram, machine_type, disk_size, boot_disk_size,
         preemptible, image, logging, logging_path, regions, zones, scopes,
         keep_alive, cpu_platform, network, subnetwork, use_private_address,
-        accelerator_type, accelerator_count, timeout)
+        accelerator_type, accelerator_count, timeout, log_interval)
 
 
 def ensure_job_params_are_complete(job_params):

--- a/dsub/lib/job_model.py
+++ b/dsub/lib/job_model.py
@@ -328,7 +328,7 @@ class Resources(
         'preemptible', 'image', 'logging', 'logging_path', 'regions', 'zones',
         'scopes', 'keep_alive', 'cpu_platform', 'network', 'subnetwork',
         'use_private_address', 'accelerator_type', 'accelerator_count',
-        'timeout', 'log_interval'
+        'timeout', 'log_interval', 'ssh'
     ])):
   """Job resource parameters related to CPUs, memory, and disk.
 
@@ -355,6 +355,7 @@ class Resources(
       attach.
     timeout (string): The max amount of time to give the pipeline to complete.
     log_interval (string): The amount of time to sleep between log uploads.
+    ssh (bool): Start an SSH container in the background.
   """
   __slots__ = ()
 
@@ -379,12 +380,13 @@ class Resources(
               accelerator_type=None,
               accelerator_count=0,
               timeout=None,
-              log_interval=None):
+              log_interval=None,
+              ssh=None):
     return super(Resources, cls).__new__(
         cls, min_cores, min_ram, machine_type, disk_size, boot_disk_size,
         preemptible, image, logging, logging_path, regions, zones, scopes,
         keep_alive, cpu_platform, network, subnetwork, use_private_address,
-        accelerator_type, accelerator_count, timeout, log_interval)
+        accelerator_type, accelerator_count, timeout, log_interval, ssh)
 
 
 def ensure_job_params_are_complete(job_params):

--- a/dsub/lib/param_util.py
+++ b/dsub/lib/param_util.py
@@ -789,37 +789,46 @@ def age_to_create_time(age, from_time=None):
     raise ValueError('Unable to parse age string %s: %s' % (age, e))
 
 
-def timeout_in_seconds(timeout):
+def _interval_to_seconds(interval, valid_units='smhdw'):
   """Convert the timeout duration to seconds.
 
   The value must be of the form "<integer><unit>" where supported
   units are s, m, h, d, w (seconds, minutes, hours, days, weeks).
 
   Args:
-    timeout: A "<integer><unit>" string.
+    interval: A "<integer><unit>" string.
+    valid_units: A list of supported units.
 
   Returns:
-    A string of the form "<integer><unit>" or None if timeout is empty.
+    A string of the form "<integer>s" or None if timeout is empty.
   """
-  if not timeout:
+  if not interval:
     return None
 
   try:
-    last_char = timeout[-1]
+    last_char = interval[-1]
 
-    if last_char == 's':
-      return str(float(timeout[:-1])) + 's'
-    elif last_char == 'm':
-      return str(float(timeout[:-1]) * 60) + 's'
-    elif last_char == 'h':
-      return str(float(timeout[:-1]) * 60 * 60) + 's'
-    elif last_char == 'd':
-      return str(float(timeout[:-1]) * 60 * 60 * 24) + 's'
-    elif last_char == 'w':
-      return str(float(timeout[:-1]) * 60 * 60 * 24 * 7) + 's'
+    if last_char == 's' and 's' in valid_units:
+      return str(float(interval[:-1])) + 's'
+    elif last_char == 'm' and 'm' in valid_units:
+      return str(float(interval[:-1]) * 60) + 's'
+    elif last_char == 'h' and 'h' in valid_units:
+      return str(float(interval[:-1]) * 60 * 60) + 's'
+    elif last_char == 'd' and 'd' in valid_units:
+      return str(float(interval[:-1]) * 60 * 60 * 24) + 's'
+    elif last_char == 'w' and 'w' in valid_units:
+      return str(float(interval[:-1]) * 60 * 60 * 24 * 7) + 's'
     else:
       raise ValueError(
-          'Unsupported units in timeout string %s: %s' % (timeout, last_char))
+          'Unsupported units in interval string %s: %s' % (interval, last_char))
 
   except (ValueError, OverflowError) as e:
-    raise ValueError('Unable to parse timeout string %s: %s' % (timeout, e))
+    raise ValueError('Unable to parse interval string %s: %s' % (interval, e))
+
+
+def timeout_in_seconds(timeout):
+  return _interval_to_seconds(timeout, valid_units='smhdw')
+
+
+def log_interval_in_seconds(log_interval):
+  return _interval_to_seconds(log_interval, valid_units='smh')

--- a/dsub/providers/google.py
+++ b/dsub/providers/google.py
@@ -948,6 +948,8 @@ class GoogleOperation(base.Task):
       value = self._get_operation_input_field_values(metadata, True)
     elif field == 'outputs':
       value = self._get_operation_output_field_values(metadata)
+    elif field == 'mounts':
+      value = None
     elif field == 'create-time':
       value = google_base.parse_rfc3339_utc_string(metadata['createTime'])
     elif field == 'start-time':

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -743,7 +743,9 @@ class GoogleV2JobProvider(base.JobProvider):
 
     # If this is a dry-run, emit all the pipeline request objects
     if self._dry_run:
-      print(json.dumps(requests, indent=2, sort_keys=True))
+      print(
+          json.dumps(
+              requests, indent=2, sort_keys=True, separators=(',', ': ')))
 
     if not requests and not launched_tasks:
       return {'job-id': dsub_util.NO_JOB}

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -58,6 +58,9 @@ _PYTHON_IMAGE = 'python:2.7-slim'
 _SSH_IMAGE = 'gcr.io/cloud-genomics-pipelines/tools'
 _DEFAULT_SSH_PORT = 22
 
+# This image is for an optional mount on a bucket using GCS Fuse
+_GCSFUSE_IMAGE = 'gcr.io/cloud-genomics-pipelines/gcsfuse:latest'
+
 # Name of the data disk
 _DATA_DISK_NAME = 'datadisk'
 
@@ -426,7 +429,7 @@ class GoogleV2JobProvider(base.JobProvider):
         'STDERR_PATH': '{}-stderr.log'.format(logging_prefix)
     }
 
-  def _get_prepare_env(self, script, job_descriptor, inputs, outputs):
+  def _get_prepare_env(self, script, job_descriptor, inputs, outputs, mounts):
     """Return a dict with variables for the 'prepare' action."""
 
     # Add the _SCRIPT_REPR with the repr(script) contents
@@ -447,7 +450,7 @@ class GoogleV2JobProvider(base.JobProvider):
 
     docker_paths = sorted([
         var.docker_path if var.recursive else os.path.dirname(var.docker_path)
-        for var in inputs | outputs
+        for var in inputs | outputs | mounts
         if var.value
     ])
 
@@ -518,13 +521,41 @@ class GoogleV2JobProvider(base.JobProvider):
 
     return env
 
-  def _build_user_environment(self, envs, inputs, outputs):
+  def _build_user_environment(self, envs, inputs, outputs, mounts):
     """Returns a dictionary of for the user container environment."""
     envs = {env.name: env.value for env in envs}
     envs.update(providers_util.get_file_environment_variables(inputs))
     envs.update(providers_util.get_file_environment_variables(outputs))
-
+    envs.update(providers_util.get_file_environment_variables(mounts))
     return envs
+
+  def _get_mount_actions(self, mounts, mnt_datadisk):
+    """Returns a list of two actions per gcs bucket to mount."""
+    actions_to_add = []
+    for mount in mounts:
+      bucket = mount.value[len('gs://'):]
+      mount_path = mount.docker_path
+      actions_to_add.extend([
+          google_v2_pipelines.build_action(
+              name='mount-{}'.format(bucket),
+              flags=['ENABLE_FUSE', 'RUN_IN_BACKGROUND'],
+              image_uri=_GCSFUSE_IMAGE,
+              mounts=[mnt_datadisk],
+              commands=[
+                  '--implicit-dirs', '--foreground', bucket,
+                  os.path.join(providers_util.DATA_MOUNT_POINT, mount_path)
+              ]),
+          google_v2_pipelines.build_action(
+              name='mount-wait-{}'.format(bucket),
+              flags=['ENABLE_FUSE'],
+              image_uri=_GCSFUSE_IMAGE,
+              mounts=[mnt_datadisk],
+              commands=[
+                  'wait',
+                  os.path.join(providers_util.DATA_MOUNT_POINT, mount_path)
+              ])
+      ])
+    return actions_to_add
 
   def _build_pipeline_request(self, task_view):
     """Returns a Pipeline objects for the task."""
@@ -549,6 +580,14 @@ class GoogleV2JobProvider(base.JobProvider):
         | job_params['labels'] | task_params['labels']
     }
 
+    # Set local variables for the core pipeline values
+    script = task_view.job_metadata['script']
+
+    envs = job_params['envs'] | task_params['envs']
+    inputs = job_params['inputs'] | task_params['inputs']
+    outputs = job_params['outputs'] | task_params['outputs']
+    mounts = job_params['mounts']
+
     # The list of "actions" (1-based) will be:
     #   1- continuous copy of log files off to Cloud Storage
     #   2- prepare the shared mount point (write the user script)
@@ -560,15 +599,23 @@ class GoogleV2JobProvider(base.JobProvider):
     # If the user has requested an SSH server be started, it will be inserted
     # after logging is started, and all subsequent action numbers above will be
     # incremented by 1.
-
+    # If the user has requested to mount one or more buckets, two actions per
+    # bucket will be inserted after the prepare step, and all subsequent action
+    # numbers will be incremented by the number of actions added.
+    #
+    # We need to track the action numbers specifically for the user action and
+    # the final logging action.
     optional_actions = 0
     if job_resources.ssh:
       optional_actions += 1
 
+    mount_actions = self._get_mount_actions(mounts, mnt_datadisk)
+    optional_actions += len(mount_actions)
+
     user_action = 4 + optional_actions
     final_logging_action = 6 + optional_actions
 
-    # Set up the logging command
+    # Set up the commands and environment for the logging actions
     log_cp_cmd = _LOG_CP_CMD.format(user_action=user_action)
     logging_cmd = _LOGGING_CMD.format(
         log_cp_fn=_GSUTIL_CP_FN, log_cp_cmd=log_cp_cmd)
@@ -579,18 +626,8 @@ class GoogleV2JobProvider(base.JobProvider):
         log_interval=job_resources.log_interval or '60s')
     logging_env = self._get_logging_env(task_resources.logging_path.uri)
 
-    # Set up user script and environment
-    script = task_view.job_metadata['script']
-
-    envs = job_params['envs'] | task_params['envs']
-    inputs = job_params['inputs'] | task_params['inputs']
-    outputs = job_params['outputs'] | task_params['outputs']
-    user_environment = self._build_user_environment(envs, inputs, outputs)
-
-    prepare_env = self._get_prepare_env(script, task_view, inputs, outputs)
-    localization_env = self._get_localization_env(inputs)
-    delocalization_env = self._get_delocalization_env(outputs)
-
+    # Set up command and environments for the prepare, localization, user,
+    # and de-localization actions
     script_path = os.path.join(providers_util.SCRIPT_DIR, script.name)
     prepare_command = _PREPARE_CMD.format(
         mk_runtime_dirs=_MK_RUNTIME_DIRS_CMD,
@@ -599,6 +636,14 @@ class GoogleV2JobProvider(base.JobProvider):
         script_path=script_path,
         mk_io_dirs=_MK_IO_DIRS)
 
+    prepare_env = self._get_prepare_env(script, task_view, inputs, outputs,
+                                        mounts)
+    localization_env = self._get_localization_env(inputs)
+    user_environment = self._build_user_environment(envs, inputs, outputs,
+                                                    mounts)
+    delocalization_env = self._get_delocalization_env(outputs)
+
+    # Build the list of actions
     actions = []
     actions.append(
         google_v2_pipelines.build_action(
@@ -619,14 +664,18 @@ class GoogleV2JobProvider(base.JobProvider):
               port_mappings={_DEFAULT_SSH_PORT: _DEFAULT_SSH_PORT},
               flags='RUN_IN_BACKGROUND'))
 
-    actions.extend([
+    actions.append(
         google_v2_pipelines.build_action(
             name='prepare',
             image_uri=_PYTHON_IMAGE,
             mounts=[mnt_datadisk],
             environment=prepare_env,
             entrypoint='/bin/bash',
-            commands=['-c', prepare_command]),
+            commands=['-c', prepare_command]),)
+
+    actions.extend(mount_actions)
+
+    actions.extend([
         google_v2_pipelines.build_action(
             name='localization',
             image_uri=_CLOUD_SDK_IMAGE,
@@ -678,6 +727,7 @@ class GoogleV2JobProvider(base.JobProvider):
     assert len(actions) - 2 == user_action
     assert len(actions) == final_logging_action
 
+    # Prepare the VM (resources) configuration
     disks = [
         google_v2_pipelines.build_disk(_DATA_DISK_NAME, job_resources.disk_size)
     ]
@@ -710,6 +760,7 @@ class GoogleV2JobProvider(base.JobProvider):
             cpu_platform=job_resources.cpu_platform),
     )
 
+    # Build the pipeline request
     pipeline = google_v2_pipelines.build_pipeline(actions, resources, None,
                                                   job_resources.timeout)
 
@@ -1162,6 +1213,12 @@ class GoogleOperation(base.Task):
               self._job_descriptor.job_params,
               self._job_descriptor.task_descriptors[0].task_params, field)
           value.update({item.name: item.value for item in items})
+    elif field == 'mounts':
+      if self._job_descriptor:
+        items = providers_util.get_job_and_task_param(
+            self._job_descriptor.job_params,
+            self._job_descriptor.task_descriptors[0].task_params, field)
+        value = {item.name: item.value for item in items}
     elif field == 'create-time':
       ds = google_v2_operations.get_create_time(self._op)
       value = google_base.parse_rfc3339_utc_string(ds)

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -70,20 +70,26 @@ _GSUTIL_CP_FN = textwrap.dedent("""\
     local src="${1}"
     local dst="${2}"
     local check_src="${3:-}"
+    local content_type="${4:-}"
 
     if [[ "${check_src}" == "true" ]] && [[ ! -e "${src}" ]]; then
       return
     fi
 
+    local headers=""
+    if [[ -n "${content_type}" ]]; then
+      headers="-h Content-Type:${content_type}"
+    fi
+
     local i
     for ((i = 0; i < 3; i++)); do
-      echo "gsutil -mq cp \"${src}\" \"${dst}\""
-      if gsutil -mq cp "${src}" "${dst}"; then
+      echo "gsutil ${headers} -mq cp \"${src}\" \"${dst}\""
+      if gsutil ${headers} -mq cp "${src}" "${dst}"; then
         return
       fi
     done
 
-    2>&1 echo "ERROR: gsutil -mq cp \"${src}\" \"${dst}\""
+    2>&1 echo "ERROR: gsutil ${headers} -mq cp \"${src}\" \"${dst}\""
     exit 1
   }
 """)
@@ -130,9 +136,9 @@ _GSUTIL_RSYNC_FN = textwrap.dedent("""\
 # the operation to indicate why it failed.
 
 _LOG_CP_CMD = textwrap.dedent("""\
-  gsutil_cp /google/logs/action/{user_action}/stdout "${{STDOUT_PATH}}" "true" &
-  gsutil_cp /google/logs/action/{user_action}/stderr "${{STDERR_PATH}}" "true" &
-  gsutil_cp /google/logs/output "${{LOGGING_PATH}}" &
+  gsutil_cp /google/logs/action/{user_action}/stdout "${{STDOUT_PATH}}" "true" "text/plain" &
+  gsutil_cp /google/logs/action/{user_action}/stderr "${{STDERR_PATH}}" "true" "text/plain" &
+  gsutil_cp /google/logs/output "${{LOGGING_PATH}}" "false" "text/plain" &
 
   wait
 """)

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -77,13 +77,13 @@ _GSUTIL_CP_FN = textwrap.dedent("""\
 
     local i
     for ((i = 0; i < 3; i++)); do
-      echo "gsutil -m cp \"${src}\" \"${dst}\""
-      if gsutil -m cp "${src}" "${dst}"; then
+      echo "gsutil -mq cp \"${src}\" \"${dst}\""
+      if gsutil -mq cp "${src}" "${dst}"; then
         return
       fi
     done
 
-    2>&1 echo "ERROR: gsutil -m cp \"${src}\" \"${dst}\""
+    2>&1 echo "ERROR: gsutil -mq cp \"${src}\" \"${dst}\""
     exit 1
   }
 """)
@@ -102,13 +102,13 @@ _GSUTIL_RSYNC_FN = textwrap.dedent("""\
 
     local i
     for ((i = 0; i < 3; i++)); do
-      echo "gsutil -m rsync -r \"${src}\" \"${dst}\""
-      if gsutil -m rsync -r "${src}" "${dst}"; then
+      echo "gsutil -mq rsync -r \"${src}\" \"${dst}\""
+      if gsutil -mq rsync -r "${src}" "${dst}"; then
         return
       fi
     done
 
-    2>&1 echo "ERROR: gsutil -m rsync -r \"${src}\" \"${dst}\""
+    2>&1 echo "ERROR: gsutil -mq rsync -r \"${src}\" \"${dst}\""
     exit 1
   }
 """)

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -15,12 +15,6 @@
 
 This module implements job creation, listing, and canceling using the
 Google Genomics Pipelines and Operations APIs v2alpha1.
-
-Status: *early* development
-Much still to be done just on launching a pipeline, including localization,
-delocalization, logging.
-Need to figure out support for generic scripts (currently only supports bash).
-Then dstat/ddel support.
 """
 from __future__ import absolute_import
 from __future__ import division
@@ -158,7 +152,7 @@ _CONTINUOUS_LOGGING_CMD = textwrap.dedent("""\
   while [[ ! -d /google/logs/action/{final_logging_action} ]]; do
     {log_cp_cmd}
 
-    sleep 10s
+    sleep {log_interval}
   done
 """)
 
@@ -568,7 +562,8 @@ class GoogleV2JobProvider(base.JobProvider):
     continuous_logging_cmd = _CONTINUOUS_LOGGING_CMD.format(
         log_cp_fn=_GSUTIL_CP_FN,
         log_cp_cmd=log_cp_cmd,
-        final_logging_action=final_logging_action)
+        final_logging_action=final_logging_action,
+        log_interval=job_resources.log_interval or '60s')
     logging_env = self._get_logging_env(task_resources.logging_path.uri)
 
     # Set up user script and environment

--- a/dsub/providers/google_v2_operations.py
+++ b/dsub/providers/google_v2_operations.py
@@ -133,6 +133,20 @@ def get_last_event(op):
   return None
 
 
+def get_event_of_type(op, event_type):
+  """Return all events of a particular type."""
+  events = get_events(op)
+  if not events:
+    return None
+
+  return [e for e in events if e.get('details', {}).get('@type') == event_type]
+
+
+def get_worker_assigned_events(op):
+  return get_event_of_type(
+      op, 'type.googleapis.com/google.genomics.v2alpha1.WorkerAssignedEvent')
+
+
 def get_last_update(op):
   """Return the most recent timestamp in the operation."""
   last_update = get_end_time(op)

--- a/examples/custom_scripts/README.md
+++ b/examples/custom_scripts/README.md
@@ -55,6 +55,7 @@ To run a Bash script to decompress the VCF file, type:
 
 ```
 dsub \
+  --provider google-v2 \
   --project MY-PROJECT \
   --zones "us-central1-*" \
   --logging "gs://MY-BUCKET/get_vcf_sample_ids.sh/logging" \
@@ -133,6 +134,7 @@ To run a Python script to decompress the VCF file, type:
 
 ```
 dsub \
+  --provider google-v2 \
   --project MY-PROJECT \
   --zones "us-central1-*" \
   --logging "gs://MY-BUCKET/get_vcf_sample_ids.py/logging" \
@@ -219,6 +221,7 @@ Run either of the following commands:
 
 ```
 dsub \
+  --provider google-v2 \
   --project MY-PROJECT \
   --zones "us-central1-*" \
   --logging "gs://MY-BUCKET/get_vcf_sample_ids/logging" \
@@ -231,6 +234,7 @@ dsub \
 
 ```
 dsub \
+  --provider google-v2 \
   --project MY-PROJECT \
   --zones "us-central1-*" \
   --logging "gs://MY-BUCKET/get_vcf_sample_ids/logging" \

--- a/examples/custom_scripts/submit_list.sh
+++ b/examples/custom_scripts/submit_list.sh
@@ -57,6 +57,7 @@ echo
 
 # Launch the task
 dsub \
+  --provider google-v2 \
   --project "${MY_PROJECT}" \
   --zones "us-central1-*" \
   --logging "${LOGGING}" \

--- a/examples/custom_scripts/submit_one.sh
+++ b/examples/custom_scripts/submit_one.sh
@@ -60,6 +60,7 @@ echo
 
 # Launch the task
 dsub \
+  --provider google-v2 \
   --project "${MY_PROJECT}" \
   --zones "us-central1-*" \
   --logging "${LOGGING}" \

--- a/examples/decompress/README.md
+++ b/examples/decompress/README.md
@@ -33,6 +33,7 @@ To run a command to decompress the VCF file, type:
 
 ```
 dsub \
+  --provider google-v2 \
   --project MY-PROJECT \
   --zones "us-central1-*" \
   --logging "gs://MY-BUCKET/decompress_one/logging" \
@@ -121,6 +122,7 @@ output file name.
 
 ```
 dsub \
+  --provider google-v2 \
   --project MY-PROJECT \
   --zones "us-central1-*" \
   --logging "gs://MY-BUCKET/decompress_list/logging" \

--- a/examples/decompress/submit_list.sh
+++ b/examples/decompress/submit_list.sh
@@ -34,6 +34,7 @@ readonly SCRIPT_DIR="$(dirname "${0}")"
 
 # Launch the task
 dsub \
+  --provider google-v2 \
   --project "${MY_PROJECT}" \
   --zones "us-central1-*" \
   --logging "${MY_BUCKET}/decompress_list/logging/" \

--- a/examples/decompress/submit_one.sh
+++ b/examples/decompress/submit_one.sh
@@ -35,6 +35,7 @@ readonly SCRIPT_DIR="$(dirname "${0}")"
 
 # Launch the task
 dsub \
+  --provider google-v2 \
   --project "${MY_PROJECT}" \
   --zones "us-central1-*" \
   --logging "${MY_BUCKET_PATH}"/logging/ \

--- a/examples/fastqc/README.md
+++ b/examples/fastqc/README.md
@@ -77,6 +77,7 @@ To run FastQC on the BAM file, type:
 
 ```
 dsub \
+  --provider google-v2 \
   --project MY-PROJECT \
   --zones "us-central1-*" \
   --logging "gs://MY-BUCKET/fastqc/submit_one/logging" \
@@ -98,9 +99,9 @@ You should see output like:
 Job: fastqc--<userid>--170619-105212-67
 Launched job-id: fastqc--<userid>--170619-105212-67
 To check the status, run:
-  dstat --project MY-PROJECT --jobs fastqc--<userid>--170619-105212-67 --status '*'
+  dstat --provider google-v2 --project MY-PROJECT --jobs fastqc--<userid>--170619-105212-67 --status '*'
 To cancel the job, run:
-  ddel --project MY-PROJECT --jobs fastqc--<userid>--170619-105212-67
+  ddel --provider google-v2 --project MY-PROJECT --jobs fastqc--<userid>--170619-105212-67
 Waiting for job to complete...
 Waiting for: fastqc--<userid>--170619-105212-67.
 ```
@@ -155,6 +156,7 @@ output file name.
 
 ```
 dsub \
+  --provider google-v2 \
   --project MY-PROJECT \
   --zones "us-central1-*" \
   --logging "gs://MY-BUCKET/samtools/submit_list/logging" \
@@ -173,9 +175,9 @@ Job: fastqc--<userid>--170522-154943-70
 Launched job-id: fastqc--<userid>--170522-154943-70
 3 task(s)
 To check the status, run:
-  dstat --project MY-PROJECT --jobs fastqc--<userid>--170522-154943-70 --status '*'
+  dstat --provider google-v2 --project MY-PROJECT --jobs fastqc--<userid>--170522-154943-70 --status '*'
 To cancel the job, run:
-  ddel --project MY-PROJECT --jobs fastqc--<userid>--170522-154943-70
+  ddel --provider google-v2 --project MY-PROJECT --jobs fastqc--<userid>--170522-154943-70
 Waiting for job to complete...
 Waiting for: fastqc--<userid>--170522-154943-70.
 ```

--- a/examples/fastqc/submit_list.sh
+++ b/examples/fastqc/submit_list.sh
@@ -40,6 +40,7 @@ gcloud builds submit "${SCRIPT_DIR}" \
 
 # Launch the task
 dsub \
+  --provider google-v2 \
   --project "${MY_PROJECT}" \
   --zones "us-central1-*" \
   --logging "${OUTPUT_ROOT}/logging/" \

--- a/examples/fastqc/submit_one.sh
+++ b/examples/fastqc/submit_one.sh
@@ -41,6 +41,7 @@ gcloud builds submit "${SCRIPT_DIR}" \
 
 # Launch the task
 dsub \
+  --provider google-v2 \
   --project "${MY_PROJECT}" \
   --zones "us-central1-*" \
   --logging "${OUTPUT_ROOT}/logging" \

--- a/examples/samtools/README.md
+++ b/examples/samtools/README.md
@@ -38,6 +38,7 @@ To run a command to index the BAM file, type:
 
 ```
 dsub \
+  --provider google-v2 \
   --project MY-PROJECT \
   --zones "us-central1-*" \
   --logging "gs://MY-BUCKET/samtools/submit_one/logging" \
@@ -62,9 +63,9 @@ You should see output like:
 Job: samtools-i--<userid>--170522-153810-14
 Launched job-id: samtools-i--<userid>--170522-153810-14
 To check the status, run:
-  dstat --project MY-PROJECT --jobs samtools-i--<userid>--170522-153810-14 --status '*'
+  dstat --provider google-v2 --project MY-PROJECT --jobs samtools-i--<userid>--170522-153810-14 --status '*'
 To cancel the job, run:
-  ddel --project MY-PROJECT --jobs samtools-i--<userid>--170522-153810-14
+  ddel --provider google-v2 --project MY-PROJECT --jobs samtools-i--<userid>--170522-153810-14
 Waiting for job to complete...
 Waiting for: samtools-i--<userid>--170522-153810-14.
 ```
@@ -118,6 +119,7 @@ output file name.
 
 ```
 dsub \
+  --provider google-v2 \
   --project MY-PROJECT \
   --zones "us-central1-*" \
   --logging "gs://MY-BUCKET/samtools/submit_list/logging" \
@@ -139,9 +141,9 @@ Job: samtools-i--<userid>--170522-154943-70
 Launched job-id: samtools-i--<userid>--170522-154943-70
 3 task(s)
 To check the status, run:
-  dstat --project MY-PROJECT --jobs samtools-i--<userid>--170522-154943-70 --status '*'
+  dstat --provider google-v2 --project MY-PROJECT --jobs samtools-i--<userid>--170522-154943-70 --status '*'
 To cancel the job, run:
-  ddel --project MY-PROJECT --jobs samtools-i--<userid>--170522-154943-70
+  ddel --provider google-v2 --project MY-PROJECT --jobs samtools-i--<userid>--170522-154943-70
 Waiting for job to complete...
 Waiting for: samtools-i--<userid>--170522-154943-70.
 ```

--- a/examples/samtools/submit_list.sh
+++ b/examples/samtools/submit_list.sh
@@ -36,6 +36,7 @@ readonly SCRIPT_DIR="$(dirname "${0}")"
 
 # Launch the task
 dsub \
+  --provider google-v2 \
   --project "${MY_PROJECT}" \
   --zones "us-central1-*" \
   --logging "${OUTPUT_ROOT}/logging/" \

--- a/examples/samtools/submit_one.sh
+++ b/examples/samtools/submit_one.sh
@@ -37,6 +37,7 @@ readonly SCRIPT_DIR="$(dirname "${0}")"
 
 # Launch the task
 dsub \
+  --provider google-v2 \
   --project "${MY_PROJECT}" \
   --zones "us-central1-*" \
   --logging "${OUTPUT_ROOT}"/logging \

--- a/test/integration/e2e_dstat.sh
+++ b/test/integration/e2e_dstat.sh
@@ -148,8 +148,8 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
   fi
 
   verify_dstat_output "${DSTAT_OUTPUT}"
-  if [[ "${DSUB_PROVIDER}" == "google" ]]; then
-    echo "Checking dstat google provider fields"
+  if [[ "${DSUB_PROVIDER}" == "google" ]] || [[ "${DSUB_PROVIDER}" == "google-v2" ]]; then
+    echo "Checking dstat ${DSUB_PROVIDER} provider fields"
     verify_dstat_google_provider_fields "${DSTAT_OUTPUT}"
   fi
 
@@ -190,8 +190,8 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
   fi
 
   verify_dstat_output "${DSTAT_OUTPUT}"
-  if [[ "${DSUB_PROVIDER}" == "google" ]]; then
-    echo "Checking dstat google provider fields"
+  if [[ "${DSUB_PROVIDER}" == "google" ]] || [[ "${DSUB_PROVIDER}" == "google-v2" ]]; then
+    echo "Checking dstat ${DSUB_PROVIDER} provider fields"
     verify_dstat_google_provider_fields "${DSTAT_OUTPUT}"
   fi
 

--- a/test/integration/e2e_io_fuse.google-v2.sh
+++ b/test/integration/e2e_io_fuse.google-v2.sh
@@ -17,18 +17,13 @@
 set -o errexit
 set -o nounset
 
-# Test copying input files to and output files from directories.
+# Test gcsfuse abilities.
 #
-# This test is designed to verify that named file input and output path
+# This test is designed to verify that named GCS bucket (mount)
 # command-line parameters work correctly.
 #
-# The actual operation performed here is to download a BAM and compute
-# the md5, writing it to <filename>.bam.md5.
-#
-# An input file (the BAM) is localized to a subdirectory of the default
-# data directory.
-# An output file (the MD5) is de-localized from a different subdirectory
-# of the default data directory.
+# The actual operation performed here is to mount to a bucket containing a BAM
+# and compute its md5, writing it to <filename>.bam.md5.
 
 readonly SCRIPT_DIR="$(dirname "${0}")"
 
@@ -42,10 +37,10 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
 
   echo "Launching pipeline..."
 
-  JOB_ID=$(io_setup::run_dsub)
+  JOB_ID=$(io_setup::run_dsub_fuse)
 
 fi
 
 # Do validation
 io_setup::check_output
-io_setup::check_dstat "${JOB_ID}" true false
+io_setup::check_dstat "${JOB_ID}" false true

--- a/test/integration/e2e_io_tasks.py
+++ b/test/integration/e2e_io_tasks.py
@@ -66,7 +66,7 @@ if not os.environ.get('CHECK_RESULTS_ONLY'):
       '--script', '%s/script_io_test.sh' % test.TEST_DIR,
       '--tasks', test.TASKS_FILE,
       '--env', 'TEST_NAME=%s' % test.TEST_NAME,
-      '--input', 'POPULATION_FILE=%s' % POPULATION_FILE,
+      '--input', 'POPULATION_FILE_PATH=%s' % POPULATION_FILE,
       '--output', 'OUTPUT_POPULATION_FILE=%s/*' % test.OUTPUTS,
       '--wait'])
   # pyformat: enable

--- a/test/integration/e2e_non_root.sh
+++ b/test/integration/e2e_non_root.sh
@@ -69,13 +69,21 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
   echo "Creating image using Google Cloud Build"
 
   mkdir -p "${BUILD_DIR}"
+  ENTRYPOINT=""
+  if [[ "${DSUB_PROVIDER}" != "google" ]]; then
+    ENTRYPOINT='ENTRYPOINT [ "sh", "-c", "exit 1" ]'
+  fi
   sed -e 's#^ *##' > "${DOCKERFILE}" <<-EOF
-    FROM ubuntu:14.04
+    FROM alpine:latest
+
+    RUN apk add --no-cache bash
 
     RUN adduser test_user \
       --disabled-password --gecos "First Last,RoomNumber,WorkPhone,HomePhone"
 
     USER test_user
+
+    ${ENTRYPOINT}
 EOF
 
   gcloud builds submit "${BUILD_DIR}" \

--- a/test/integration/e2e_non_root.sh
+++ b/test/integration/e2e_non_root.sh
@@ -69,9 +69,11 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
   echo "Creating image using Google Cloud Build"
 
   mkdir -p "${BUILD_DIR}"
-  ENTRYPOINT=""
-  if [[ "${DSUB_PROVIDER}" != "google" ]]; then
-    ENTRYPOINT='ENTRYPOINT [ "sh", "-c", "exit 1" ]'
+  ENTRYPOINT='ENTRYPOINT [ "sh", "-c", "exit 1" ]'
+  if [[ "${DSUB_PROVIDER}" == "google" ]]; then
+    # The original google provider could not support Docker images with
+    # entrypoints because the Pipelines API v1alpha2 did not.
+    ENTRYPOINT=""
   fi
   sed -e 's#^ *##' > "${DOCKERFILE}" <<-EOF
     FROM alpine:latest
@@ -104,4 +106,4 @@ fi
 
 # Do validation
 io_setup::check_output
-io_setup::check_dstat "${JOB_ID}"
+io_setup::check_dstat "${JOB_ID}" true false

--- a/test/integration/get_data_value.py
+++ b/test/integration/get_data_value.py
@@ -127,6 +127,9 @@ def main():
         sys.exit(1)
 
       if idx >= len(curr):
+        print('Index of key out of bounds', file=sys.stderr)
+        print('Key: %s' % key, file=sys.stderr)
+        print('Value: %s' % curr, file=sys.stderr)
         sys.exit(1)
 
       curr = curr[idx]
@@ -136,6 +139,9 @@ def main():
     if key in curr:
       curr = curr[key]
     else:
+      print('Key not found', file=sys.stderr)
+      print('Key: %s' % key, file=sys.stderr)
+      print('Value: %s' % curr, file=sys.stderr)
       sys.exit(1)
 
   print(curr)

--- a/test/integration/io_tasks_setup.sh
+++ b/test/integration/io_tasks_setup.sh
@@ -50,7 +50,7 @@ function io_tasks_setup::run_dsub() {
     --script "${io_tasks_script}" \
     --tasks "${io_tasks_file}" \
     --env TEST_NAME="${TEST_NAME}" \
-    --input POPULATION_FILE="${POPULATION_FILE}" \
+    --input POPULATION_FILE_PATH="${POPULATION_FILE}" \
     --output OUTPUT_POPULATION_FILE="${OUTPUTS}/*" \
     --wait
 }
@@ -142,7 +142,7 @@ function io_tasks_setup::check_dstat() {
 
     echo "  Checking inputs..."
     util::dstat_yaml_assert_field_equal "${dstat_output}" "[0].inputs.INPUT_PATH" "${INPUT_BAMS[$((task_id-1))]}"
-    util::dstat_yaml_assert_field_equal "${dstat_output}" "[0].inputs.POPULATION_FILE" "${POPULATION_FILE}"
+    util::dstat_yaml_assert_field_equal "${dstat_output}" "[0].inputs.POPULATION_FILE_PATH" "${POPULATION_FILE}"
 
     echo "  Checking outputs..."
     util::dstat_yaml_assert_field_equal "${dstat_output}" "[0].outputs.OUTPUT_PATH" "${OUTPUTS}/${task_id}/*.md5"

--- a/test/integration/unit_flags.google-v2.sh
+++ b/test/integration/unit_flags.google-v2.sh
@@ -329,6 +329,43 @@ function test_no_timeout() {
 }
 readonly -f test_no_timeout
 
+function test_log_interval() {
+  local subtest="${FUNCNAME[0]}"
+
+  if call_dsub \
+    --command 'echo "${TEST_NAME}"' \
+    --regions us-central1 \
+    --log-interval '1h'; then
+
+    # Check that the output contains expected values
+    assert_err_value_matches \
+     "[0].pipeline.actions.[0].commands.[1]" "3600.0s"
+
+    test_passed "${subtest}"
+  else
+    test_failed "${subtest}"
+  fi
+}
+readonly -f test_log_interval
+
+function test_no_log_interval() {
+  local subtest="${FUNCNAME[0]}"
+
+  if call_dsub \
+    --command 'echo "${TEST_NAME}"' \
+    --regions us-central1; then
+
+    # Check that the output contains expected values
+    assert_err_value_matches \
+     "[0].pipeline.actions.[0].commands.[1]" "60s"
+
+    test_passed "${subtest}"
+  else
+    test_failed "${subtest}"
+  fi
+}
+readonly -f test_no_log_interval
+
 # Run the tests
 trap "exit_handler" EXIT
 
@@ -360,3 +397,6 @@ echo
 test_timeout
 test_no_timeout
 
+echo
+test_log_interval
+test_no_log_interval

--- a/test/integration/unit_flags.google-v2.sh
+++ b/test/integration/unit_flags.google-v2.sh
@@ -366,6 +366,43 @@ function test_no_log_interval() {
 }
 readonly -f test_no_log_interval
 
+function test_ssh() {
+  local subtest="${FUNCNAME[0]}"
+
+  if call_dsub \
+    --command 'echo "${TEST_NAME}"' \
+    --regions us-central1 \
+    --ssh; then
+
+    # Check that the output contains expected values
+    assert_err_value_equals \
+     "[0].pipeline.actions.[1].entrypoint" "ssh-server"
+
+    test_passed "${subtest}"
+  else
+    test_failed "${subtest}"
+  fi
+}
+readonly -f test_ssh
+
+function test_no_ssh() {
+  local subtest="${FUNCNAME[0]}"
+
+  if call_dsub \
+    --command 'echo "${TEST_NAME}"' \
+    --regions us-central1; then
+
+    # Check that the output does not contain ssh values
+    assert_err_not_contains \
+     "ssh-server"
+
+    test_passed "${subtest}"
+  else
+    test_failed "${subtest}"
+  fi
+}
+readonly -f test_no_ssh
+
 # Run the tests
 trap "exit_handler" EXIT
 
@@ -400,3 +437,7 @@ test_no_timeout
 echo
 test_log_interval
 test_no_log_interval
+
+echo
+test_ssh
+test_no_ssh

--- a/test/testdata/summary_3_running.json
+++ b/test/testdata/summary_3_running.json
@@ -1,7 +1,7 @@
 [
   {
-    "job-name": "test-job", 
-    "status": "RUNNING", 
+    "job-name": "test-job",
+    "status": "RUNNING",
     "task-count": 3
   }
 ]

--- a/test/unit/job_model_test.py
+++ b/test/unit/job_model_test.py
@@ -179,6 +179,7 @@ _ENV_LIST_JOB_DESCRIPTOR = job_model.JobDescriptor(
         'labels': set(),
         'inputs': set(),
         'outputs': set(),
+        'mounts': set(),
     },
     task_descriptors=[
         job_model.TaskDescriptor(
@@ -281,6 +282,7 @@ _IO_TASKS_JOB_DESCRIPTOR = job_model.JobDescriptor(
                 'gs://b/dsub/sh/local/io_tasks/output/*',
                 recursive=False),
         },
+        'mounts': set(),
     },
     task_descriptors=[
         job_model.TaskDescriptor(
@@ -389,6 +391,7 @@ _IO_RECURSIVE_JOB_DESCRIPTOR = job_model.JobDescriptor(
                 'gs://b/dsub/sh/local/io_recursive/output/shallow/*',
                 recursive=False),
         },
+        'mounts': set(),
     },
     task_descriptors=[
         job_model.TaskDescriptor(
@@ -464,6 +467,7 @@ _LABELS_JOB_DESCRIPTOR = job_model.JobDescriptor(
         'labels': {job_model.LabelParam('batch', 'hello-world')},
         'inputs': set(),
         'outputs': set(),
+        'mounts': set(),
     },
     task_descriptors=[
         job_model.TaskDescriptor(

--- a/test/unit/param_util_test.py
+++ b/test/unit/param_util_test.py
@@ -125,8 +125,29 @@ class ParamUtilTest(unittest.TestCase):
   ])
   def test_timeout_in_seconds_fail(self, unused_name, timeout):
     del unused_name
-    with six.assertRaisesRegex(self, ValueError, 'Unable to parse timeout'):
+    with six.assertRaisesRegex(self, ValueError, 'Unable to parse interval'):
       _ = param_util.timeout_in_seconds(timeout)
+
+  @parameterized.parameterized.expand([
+      ('simple_second', '1s', '1.0s'),
+      ('simple_minute', '1m', '60.0s'),
+      ('simple_hour', '1h', '3600.0s'),
+  ])
+  def test_log_interval_in_seconds(self, unused_name, log_interval, expected):
+    del unused_name
+    result = param_util.log_interval_in_seconds(log_interval)
+    self.assertEqual(expected, result)
+
+  @parameterized.parameterized.expand([
+      ('simple_day', '1d'),
+      ('simple_week', '1w'),
+      ('bad_units', '1second'),
+      ('no_units', '123'),
+  ])
+  def test_log_interval_in_seconds_fail(self, unused_name, log_interval):
+    del unused_name
+    with six.assertRaisesRegex(self, ValueError, 'Unable to parse interval'):
+      _ = param_util.log_interval_in_seconds(log_interval)
 
 
 class FileParamUtilTest(unittest.TestCase):

--- a/test/unit/param_util_test.py
+++ b/test/unit/param_util_test.py
@@ -384,7 +384,7 @@ TASK_DESCRIPTORS = [
 class TestSubmitValidator(unittest.TestCase):
 
   def test_submit_validator_passes(self):
-    job_params = {'inputs': set(), 'outputs': set()}
+    job_params = {'inputs': set(), 'outputs': set(), 'mounts': set()}
     job_resources = job_model.Resources(
         logging=job_model.LoggingParam('gs://buck/logs', job_model.P_GCS))
     param_util.validate_submit_args_or_fail(
@@ -404,7 +404,7 @@ class TestSubmitValidator(unittest.TestCase):
        [job_model.P_LOCAL]),
   ])
   def test_submit_validator_fails(self, name, path, inwl, outwl, logwl):
-    job_params = {'inputs': set(), 'outputs': set()}
+    job_params = {'inputs': set(), 'outputs': set(), 'mounts': set()}
     job_resources = job_model.Resources(
         logging=job_model.LoggingParam('gs://buck/logs', job_model.P_GCS))
     err_expected = 'Unsupported %s path (%s) for provider' % (name, path)


### PR DESCRIPTION
This release includes:
- Documentation updates noting the deprecation of the google provider.
- `google-v2` provider updates:
  - `--log-interval` flag to configure the amount of time to sleep between copying log files from the pipeline to the logging path. 
  - Adding `google-v2` specific elements to dstat output.
  - `--ssh` flag to start an SSH container in the background, allowing you to inspect the runtime 
environment of your job's container in real time.
  - Experimental support for gcsfuse through the `--mount` flag. 
- Update Dockerfile entrypoint in local runner.