### PR TITLE
PR for 0.2.3 release

### DIFF
--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.2.2'
+DSUB_VERSION = '0.2.3.dev0'

--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.2.3.dev0'
+DSUB_VERSION = '0.2.3'

--- a/dsub/commands/ddel.py
+++ b/dsub/commands/ddel.py
@@ -126,6 +126,8 @@ def main():
 
   # Let the user know which jobs we are going to look up
   with dsub_util.replace_print():
+    provider_base.emit_provider_message(provider)
+
     _emit_search_criteria(user_ids, args.jobs, args.tasks, args.label)
     # Delete the requested jobs
     deleted_tasks = ddel_tasks(

--- a/dsub/commands/dstat.py
+++ b/dsub/commands/dstat.py
@@ -470,6 +470,8 @@ def main():
 
   # Set up the Genomics Pipelines service interface
   provider = provider_base.get_provider(args, resources)
+  with dsub_util.replace_print():
+    provider_base.emit_provider_message(provider)
 
   # Set poll interval to zero if --wait is not set.
   poll_interval = args.poll_interval if args.wait else 0

--- a/dsub/commands/dsub.py
+++ b/dsub/commands/dsub.py
@@ -1011,6 +1011,9 @@ def run(provider,
         project=None,
         disable_warning=False):
   """Actual dsub body, post-stdout-redirection."""
+  if not dry_run:
+    provider_base.emit_provider_message(provider)
+
   if not disable_warning:
     raise ValueError('Do not user this unstable API component!')
 

--- a/dsub/providers/base.py
+++ b/dsub/providers/base.py
@@ -30,16 +30,19 @@ nomenclature below will indicate "task data" even for such jobs that do not have
 explicit tasks.
 """
 
-from abc import ABCMeta
-from abc import abstractmethod
+import abc
 import six
 
 
-@six.add_metaclass(ABCMeta)
+@six.add_metaclass(abc.ABCMeta)
 class JobProvider(object):
   """Interface all job providers should inherit from."""
 
-  @abstractmethod
+  # A member field that a provider can use to expose a status message
+  # such as a deprecation notice.
+  status_message = None
+
+  @abc.abstractmethod
   def prepare_job_metadata(self, script, job_name, user_id, create_time):
     """Returns a dictionary of metadata fields for the job.
 
@@ -77,7 +80,7 @@ class JobProvider(object):
     """
     raise NotImplementedError()
 
-  @abstractmethod
+  @abc.abstractmethod
   def submit_job(self, job_descriptor, skip_if_output_present):
     """Submit the job to be executed.
 
@@ -101,7 +104,7 @@ class JobProvider(object):
     """
     raise NotImplementedError()
 
-  @abstractmethod
+  @abc.abstractmethod
   def delete_jobs(self,
                   user_ids,
                   job_ids,
@@ -132,7 +135,7 @@ class JobProvider(object):
     """
     raise NotImplementedError()
 
-  @abstractmethod
+  @abc.abstractmethod
   def lookup_job_tasks(self,
                        statuses,
                        user_ids=None,
@@ -177,7 +180,7 @@ class JobProvider(object):
     """
     raise NotImplementedError()
 
-  @abstractmethod
+  @abc.abstractmethod
   def get_tasks_completion_messages(self, tasks):
     """List of the error message of each given task."""
     raise NotImplementedError()
@@ -186,7 +189,7 @@ class JobProvider(object):
 class Task(object):
   """Basic container for task metadata."""
 
-  @abstractmethod
+  @abc.abstractmethod
   def raw_task_data(self):
     """Return a provider-specific representation of task data.
 
@@ -195,7 +198,7 @@ class Task(object):
     """
     raise NotImplementedError()
 
-  @abstractmethod
+  @abc.abstractmethod
   def get_field(self, field, default=None):
     """Return a metadata-field for the task.
 

--- a/dsub/providers/google.py
+++ b/dsub/providers/google.py
@@ -610,6 +610,21 @@ class _Operations(object):
 class GoogleJobProvider(base.JobProvider):
   """Interface to dsub and related tools for managing Google cloud jobs."""
 
+  status_message = textwrap.dedent("""
+    ** WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING **
+
+      The google provider is deprecated.
+      The underlying service (Pipelines API v1alpha2) is scheduled for turndown
+      at the end of 2018.
+
+      Please use the google-v2 provider.
+
+      See:
+        https://github.com/DataBiosphere/dsub#deprecation-of-the-google-provider
+
+    ** WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING **
+  """)
+
   def __init__(self, verbose, dry_run, project, zones=None, credentials=None):
     self._verbose = verbose
     self._dry_run = dry_run

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -412,7 +412,7 @@ class GoogleV2BatchHandler(object):
       try:
         response = cancel_fn.execute()
       except:  # pylint: disable=bare-except
-        exception = sys.exc_info()[0]
+        exception = sys.exc_info()[1]
 
       self._response_handler(request_id, response, exception)
 

--- a/dsub/providers/google_v2_operations.py
+++ b/dsub/providers/google_v2_operations.py
@@ -98,24 +98,31 @@ def get_actions(op):
   return op.get('metadata', {}).get('pipeline').get('actions', [])
 
 
-def get_action(op, name):
+def get_action_by_id(op, action_id):
+  """Return the operation's array of actions."""
+  actions = get_actions(op)
+  if actions and 1 <= action_id < len(actions):
+    return actions[action_id - 1]
+
+
+def _get_action_by_name(op, name):
   """Return the value for the specified action."""
   actions = get_actions(op)
   for action in actions:
-    if action['name'] == name:
+    if action.get('name') == name:
       return action
 
 
 def get_action_environment(op, name):
   """Return the environment for the operation."""
-  action = get_action(op, name)
+  action = _get_action_by_name(op, name)
   if action:
     return action.get('environment')
 
 
 def get_action_image(op, name):
   """Return the image for the operation."""
-  action = get_action(op, name)
+  action = _get_action_by_name(op, name)
   if action:
     return action.get('imageUri')
 
@@ -130,6 +137,16 @@ def get_last_event(op):
   events = get_events(op)
   if events:
     return events[0]
+  return None
+
+
+def get_failed_events(op):
+  """Return the events (if any) with a non-zero exitStatus."""
+  events = get_events(op)
+  if events:
+    return [
+        e for e in events if int(e.get('details', {}).get('exitStatus', 0)) != 0
+    ]
   return None
 
 

--- a/dsub/providers/local.py
+++ b/dsub/providers/local.py
@@ -83,6 +83,7 @@ import pytz
 #    status.txt: File for the runner script to record task status (RUNNING,
 #    FAILURE, etc.)
 #    log.txt: File for the runner script to write log messages
+#    runner-log.txt: Capture of all stderr/stdout from the runner script
 #    task.pid: Process ID file for task runner
 #
 # From task directory, the data directory is made available to the Docker
@@ -453,7 +454,7 @@ class LocalJobProvider(base.JobProvider):
       with open(os.path.join(task_dir, 'end-time.txt'), 'wt') as f:
         f.write(today)
       msg = 'Operation canceled at %s\n' % today
-      with open(os.path.join(task_dir, 'log.txt'), 'a') as f:
+      with open(os.path.join(task_dir, 'runner-log.txt'), 'a') as f:
         f.write(msg)
 
     return (canceled, cancel_errors)
@@ -587,7 +588,7 @@ class LocalJobProvider(base.JobProvider):
 
   def _get_last_update_time_from_task_dir(self, task_dir):
     last_update = 0
-    for filename in ['status.txt', 'log.txt', 'meta.yaml']:
+    for filename in ['status.txt', 'runner-log.txt', 'meta.yaml']:
       try:
         mtime = os.path.getmtime(os.path.join(task_dir, filename))
         last_update = max(last_update, mtime)
@@ -622,7 +623,7 @@ class LocalJobProvider(base.JobProvider):
 
   def _get_log_detail_from_task_dir(self, task_dir):
     try:
-      with open(os.path.join(task_dir, 'log.txt'), 'r') as f:
+      with open(os.path.join(task_dir, 'runner-log.txt'), 'r') as f:
         return f.read().splitlines()
     except (IOError, OSError):
       return None

--- a/dsub/providers/provider_base.py
+++ b/dsub/providers/provider_base.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 """Interface for job providers."""
+
+from __future__ import print_function
+
 import argparse
 import os
 
@@ -130,6 +133,11 @@ def get_ddel_provider_args(provider_type, project):
   """A string with the arguments to point ddel to the same provider+project."""
   # Change this if the two ever diverge.
   return get_dstat_provider_args(provider_type, project)
+
+
+def emit_provider_message(provider):
+  if provider.status_message:
+    print(provider.status_message)
 
 
 def check_for_unsupported_flag(args):

--- a/test/integration/e2e_dstat_tasks.sh
+++ b/test/integration/e2e_dstat_tasks.sh
@@ -235,7 +235,7 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
   echo "Waiting 5 seconds and checking 'dstat --age 5s'..."
   sleep 5s
 
-  DSTAT_OUTPUT="$(run_dstat_age "5s" --status '*' --jobs "${JOBID}" 2>&1)"
+  DSTAT_OUTPUT="$(run_dstat_age "5s" --status '*' --jobs "${JOBID}")"
   if [[ -n "${DSTAT_OUTPUT}" ]]; then
     echo "dstat output not empty as expected:"
     echo "${DSTAT_OUTPUT}"

--- a/test/integration/e2e_logging_fail.sh
+++ b/test/integration/e2e_logging_fail.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright 2018 Verily Life Sciences Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+
+# Test that when a bad logging path is specified, the job fails.
+
+readonly SCRIPT_DIR="$(dirname "${0}")"
+
+# Do standard test setup
+source "${SCRIPT_DIR}/test_setup_e2e.sh"
+
+readonly LOGGING_OVERRIDE="gs://__this__/path/cannot/exist"
+
+if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
+
+  echo "Launching pipeline..."
+
+  if run_dsub \
+    --command 'sleep 1m' \
+    --wait; then
+    echo "dsub did not report the failure as it should have."
+    exit 1
+  fi
+
+fi
+
+echo "SUCCESS"
+

--- a/test/unit/batch_handling_test.py
+++ b/test/unit/batch_handling_test.py
@@ -1,0 +1,48 @@
+# Copyright 2018 Verily Life Sciences Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for batch handling exceptions."""
+
+import unittest
+import apiclient.errors
+from dsub.providers import google_v2
+
+
+def callback_mock(request_id, response, exception):
+  del request_id, response  # unused
+  raise exception
+
+
+class CancelMock(object):
+
+  def __init__(self):
+    pass
+
+  def execute(self):
+    raise apiclient.errors.HttpError(None, b'test_exception')
+
+
+class TestBatchHandling(unittest.TestCase):
+
+  def test_success(self):
+    # Make a handler that executes a function that raises an http error,
+    # make sure the handler catches the error correctly
+
+    api_handler_to_test = google_v2.GoogleV2BatchHandler(callback_mock)
+    api_handler_to_test.add(CancelMock(), 'test_request_id')
+    with self.assertRaises(apiclient.errors.HttpError):
+      api_handler_to_test.execute()
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
This release includes:

* A large warning will now be emitted when using the google provider. Please use the `google-v2` provider. See https://github.com/DataBiosphere/dsub#deprecation-of-the-google-provider for details.
* Better messaging on logging failures.
* `google-v2` provider updates: 
  * Bug fixes for exception handling in large `ddel` jobs.
  