### PR TITLE
PR for 0.2.5 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ By default, dstat outputs one line per task. If you're using a batch job with
 many tasks then you may benefit from `--summary`.
 
 ```
-$ dstat --provider google-v2 --project my-project --summary
+$ dstat --provider google-v2 --project my-project --status '*' --summary
 
 Job Name        Status         Task Count
 -------------   -------------  -------------

--- a/README.md
+++ b/README.md
@@ -264,6 +264,9 @@ by passing the `--image` flag.
         --image ubuntu:16.04 \
         --script hello.sh
 
+Note: your `--image` must include the
+[Bash](https://en.wikipedia.org/wiki/Bash_(Unix_shell)) shell interpreter.
+
 ### Passing parameters to your script
 
 You can pass environment variables to your script using the `--env` flag.

--- a/docs/retries.md
+++ b/docs/retries.md
@@ -43,7 +43,7 @@ as `task-attempt`.
 
 ## Logging
 
-Logs for the retry will overwrite the original logs for that task.
+See documentation on [Logging](logging.md).
 
 ## Limitations
 

--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.2.5.dev0'
+DSUB_VERSION = '0.2.5'

--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.2.4'
+DSUB_VERSION = '0.2.5.dev0'

--- a/dsub/commands/dstat.py
+++ b/dsub/commands/dstat.py
@@ -308,6 +308,8 @@ def _prepare_row(task, full, summary):
       row_spec('events', True, []),
       row_spec('user-project', False, None),
       row_spec('dsub-version', False, None),
+      row_spec('script-name', False, None),
+      row_spec('script', False, None),
   ]
   summary_columns = default_columns + [
       row_spec('job-id', True, None),

--- a/dsub/commands/dsub.py
+++ b/dsub/commands/dsub.py
@@ -1030,7 +1030,7 @@ def run(provider,
       command_name = _name_for_command(command)
 
     # Add the shebang line to ensure the command is treated as Bash
-    script = job_model.Script(command_name, '#!/bin/bash\n' + command)
+    script = job_model.Script(command_name, '#!/usr/bin/env bash\n' + command)
   elif script:
     # Read the script file
     script_file = dsub_util.load_file(script)

--- a/dsub/commands/dsub.py
+++ b/dsub/commands/dsub.py
@@ -473,6 +473,13 @@ def _parse_arguments(prog, argv):
       action='store_true',
       help="""If set to true, start an ssh container in the background
           to allow you to log in using SSH and debug in real time.""")
+  google_v2.add_argument(
+      '--nvidia-driver-version',
+      help="""The NVIDIA driver version to use when attaching an NVIDIA GPU
+          accelerator. The version specified here must be compatible with the
+          GPU libraries contained in the container being executed, and must be
+          one of the drivers hosted in the nvidia-drivers-us-public bucket on
+          Google Cloud Storage.""")
 
   args = provider_base.parse_args(
       parser, {
@@ -524,6 +531,7 @@ def _get_job_resources(args):
       use_private_address=args.use_private_address,
       accelerator_type=args.accelerator_type,
       accelerator_count=args.accelerator_count,
+      nvidia_driver_version=args.nvidia_driver_version,
       timeout=timeout,
       log_interval=log_interval,
       ssh=args.ssh)

--- a/dsub/lib/job_model.py
+++ b/dsub/lib/job_model.py
@@ -377,7 +377,7 @@ class Resources(
         'preemptible', 'image', 'logging', 'logging_path', 'regions', 'zones',
         'scopes', 'keep_alive', 'cpu_platform', 'network', 'subnetwork',
         'use_private_address', 'accelerator_type', 'accelerator_count',
-        'timeout', 'log_interval', 'ssh'
+        'nvidia_driver_version', 'timeout', 'log_interval', 'ssh'
     ])):
   """Job resource parameters related to CPUs, memory, and disk.
 
@@ -402,6 +402,8 @@ class Resources(
     accelerator_type (string): Accelerator type (e.g. 'nvidia-tesla-k80').
     accelerator_count (int): Number of accelerators of the specified type to
       attach.
+    nvidia_driver_version (string): The NVIDIA driver version to use when
+      attaching an NVIDIA GPU accelerator.
     timeout (string): The max amount of time to give the pipeline to complete.
     log_interval (string): The amount of time to sleep between log uploads.
     ssh (bool): Start an SSH container in the background.
@@ -428,6 +430,7 @@ class Resources(
               use_private_address=None,
               accelerator_type=None,
               accelerator_count=0,
+              nvidia_driver_version=None,
               timeout=None,
               log_interval=None,
               ssh=None):
@@ -435,7 +438,8 @@ class Resources(
         cls, min_cores, min_ram, machine_type, disk_size, boot_disk_size,
         preemptible, image, logging, logging_path, regions, zones, scopes,
         keep_alive, cpu_platform, network, subnetwork, use_private_address,
-        accelerator_type, accelerator_count, timeout, log_interval, ssh)
+        accelerator_type, accelerator_count, nvidia_driver_version, timeout,
+        log_interval, ssh)
 
 
 def ensure_job_params_are_complete(job_params):

--- a/dsub/lib/job_model.py
+++ b/dsub/lib/job_model.py
@@ -608,9 +608,9 @@ class JobDescriptor(object):
         'create-time': job_metadata.get('create-time'),
         'dsub-version': job_metadata.get('dsub-version'),
         'user-project': job_metadata.get('user-project'),
+        'task-ids': job_metadata.get('task-ids'),
+        'script-name': job_metadata['script'].name,
     }
-
-    job['task-ids'] = job_metadata.get('task-ids')
 
     # logging is specified as a command-line argument and is typically
     # transformed (substituting job-id). The transformed value is saved
@@ -802,7 +802,7 @@ class JobDescriptor(object):
     job_metadata = {}
     for key in [
         'job-id', 'job-name', 'task-ids', 'user-id', 'dsub-version',
-        'user-project'
+        'user-project', 'script-name'
     ]:
       if job.get(key) is not None:
         job_metadata[key] = job.get(key)

--- a/dsub/providers/google.py
+++ b/dsub/providers/google.py
@@ -1019,7 +1019,7 @@ class GoogleOperation(base.Task):
               event['endTime'])
 
         value.append(event_value)
-    elif field == 'user-project':
+    elif field in ['user-project', 'script-name', 'script']:
       # Supported in local and google-v2 providers.
       value = None
 

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -738,9 +738,9 @@ class GoogleV2JobProvider(base.JobProvider):
             image_uri=job_resources.image,
             mounts=[mnt_datadisk] + persistent_disk_mounts,
             environment=user_environment,
-            entrypoint='/bin/bash',
+            entrypoint='/usr/bin/env',
             commands=[
-                '-c',
+                'bash', '-c',
                 _USER_CMD.format(
                     tmp_dir=providers_util.TMP_DIR,
                     working_dir=providers_util.WORKING_DIR,

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -1151,6 +1151,11 @@ class GoogleOperation(base.Task):
 
     return job_model.JobDescriptor.from_yaml(ast.literal_eval(meta))
 
+  def _try_op_to_script_body(self):
+    env = google_v2_operations.get_action_environment(self._op, _ACTION_PREPARE)
+    if env:
+      return ast.literal_eval(env.get(_SCRIPT_VARNAME))
+
   def _operation_status(self):
     """Returns the status of this operation.
 
@@ -1355,6 +1360,11 @@ class GoogleOperation(base.Task):
             value['disk-size'] = datadisk['sizeGb']
     elif field == 'events':
       value = GoogleV2EventMap(self._op).get_filtered_normalized_events()
+    elif field == 'script-name':
+      if self._job_descriptor:
+        value = self._job_descriptor.job_metadata.get(field)
+    elif field == 'script':
+      value = self._try_op_to_script_body()
     else:
       raise ValueError('Unsupported field: "%s"' % field)
 

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -823,6 +823,7 @@ class GoogleV2JobProvider(base.JobProvider):
             boot_disk_size_gb=job_resources.boot_disk_size,
             disks=disks,
             accelerators=accelerators,
+            nvidia_driver_version=job_resources.nvidia_driver_version,
             labels=labels,
             cpu_platform=job_resources.cpu_platform),
     )
@@ -1364,10 +1365,16 @@ class GoogleOperation(base.Task):
         value['zones'] = resources['zones']
       if 'virtualMachine' in resources:
         vm = resources['virtualMachine']
-        value['machine-type'] = vm['machineType']
-        value['preemptible'] = vm['preemptible']
+        value['machine-type'] = vm.get('machineType')
+        value['preemptible'] = vm.get('preemptible')
 
-        value['boot-disk-size'] = vm['bootDiskSizeGb']
+        value['boot-disk-size'] = vm.get('bootDiskSizeGb')
+        value['network'] = vm.get('network', {}).get('name')
+        value['subnetwork'] = vm.get('network', {}).get('subnetwork')
+        value['use_private_address'] = vm.get('network',
+                                              {}).get('usePrivateAddress')
+        value['cpu_platform'] = vm.get('cpuPlatform')
+        value['accelerators'] = vm.get('accelerators')
         if 'disks' in vm:
           datadisk = next(
               (d for d in vm['disks'] if d['name'] == _DATA_DISK_NAME))

--- a/dsub/providers/google_v2_pipelines.py
+++ b/dsub/providers/google_v2_pipelines.py
@@ -54,7 +54,8 @@ def build_machine(network=None,
                   disks=None,
                   accelerators=None,
                   labels=None,
-                  cpu_platform=None):
+                  cpu_platform=None,
+                  nvidia_driver_version=None):
   """Build a VirtualMachine object for a Pipeline request.
 
   Args:
@@ -67,6 +68,8 @@ def build_machine(network=None,
     accelerators (list[dict]): List of accelerators to attach to the VM.
     labels (dict[string, string]): Labels for the VM.
     cpu_platform (str): The CPU platform to request.
+    nvidia_driver_version (str): The NVIDIA driver version to use when attaching
+      an NVIDIA GPU accelerator.
 
   Returns:
     An object representing a VirtualMachine.
@@ -81,6 +84,7 @@ def build_machine(network=None,
       'accelerators': accelerators,
       'labels': labels,
       'cpuPlatform': cpu_platform,
+      'nvidiaDriverVersion': nvidia_driver_version,
   }
 
 

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
         'oauth2client',
         'python-dateutil',
         'pytz',
-        'pyyaml==3.12',
+        'pyyaml',
         'retrying',
         'six',
         'tabulate',

--- a/test/integration/e2e_cleanup.local.sh
+++ b/test/integration/e2e_cleanup.local.sh
@@ -40,8 +40,8 @@ function check_jobid {
     echo "Directory missing: ${task_dir}"
     exit 1
   fi
-
-  if [[ -d "${task_dir}/data" ]]; then
+  if [[ "$(/bin/ls ${task_dir}/data)" != "script" ]]; then
+    # It has only one script subdirectory and no other content
     echo "Directory not deleted: ${task_dir}/data"
     exit 1
   fi

--- a/test/integration/e2e_error.sh
+++ b/test/integration/e2e_error.sh
@@ -29,7 +29,7 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
   echo "Launching pipeline..."
 
   if run_dsub \
-    --image 'ubuntu' \
+    --image 'debian:stable-slim' \
     --name 'e2e-error' \
     --command 'idontknowhowtounix' \
     --wait; then

--- a/test/integration/e2e_image.sh
+++ b/test/integration/e2e_image.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Copyright 2019 Verily Life Sciences Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+
+# Basic test of using small, 'basic' images.
+#
+# No input files.
+# No output files.
+# The stdout file is checked for expected output.
+
+readonly SCRIPT_DIR="$(dirname "${0}")"
+
+# Do standard test setup
+source "${SCRIPT_DIR}/test_setup_e2e.sh"
+
+readonly IMAGE_ARRAY=("bash:4.4" "python:2-slim" "python:3-slim")
+
+# We'd also like to ensure "ubuntu:latest" and "debian:latest" images, but
+# other tests cover this.
+# ubuntu:
+#   e2e_env_tasks.sh
+#   e2e_python_api.py
+#   e2e_cleanup_local.sh
+# debian:
+#   e2e_command_flag.sh
+#   e2e_error.sh
+#   e2e_runtime.sh
+
+readonly RESULT_EXPECTED="Success!"
+
+for image in ${IMAGE_ARRAY[@]}; do
+  if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
+
+    echo "Launching pipeline..."
+
+    BOOT_DISK_SIZE=20 \
+    run_dsub \
+      --image "${image}" \
+      --command '\
+        echo "Success!"' \
+      --wait
+
+  fi
+
+  echo
+  echo "Checking output..."
+
+  # Check the results
+  RESULT="$(gsutil cat "${STDOUT_LOG}")"
+  if ! diff <(echo "${RESULT_EXPECTED}") <(echo "${RESULT}"); then
+    echo "Output file does not match expected"
+    exit 1
+  fi
+
+  echo
+  echo "Output file matches expected:"
+  echo "*****************************"
+  echo "${RESULT}"
+  echo "*****************************"
+done
+echo "SUCCESS"
+

--- a/test/integration/e2e_non_root.sh
+++ b/test/integration/e2e_non_root.sh
@@ -52,8 +52,10 @@ function check_jobid {
     exit 1
   fi
 
-  if [[ -d "${task_dir}/data" ]]; then
+  if [[ "$(/bin/ls ${task_dir}/data)" != "script" ]]; then
+    # It has only one script subdirectory and no other content
     echo "Directory not deleted: ${task_dir}/data"
+    echo "$(/bin/ls ${task_dir}/data)"
     exit 1
   fi
 }

--- a/test/integration/e2e_runtime.sh
+++ b/test/integration/e2e_runtime.sh
@@ -44,7 +44,7 @@ if [[ "${CHECK_RESULTS_ONLY:-0}" -eq 0 ]]; then
   run_dsub \
     --project "${PROJECT_ID}" \
     --logging "${LOGGING}" \
-    --image "ubuntu" \
+    --image "debian:stable-slim" \
     --name "google_env.sh" \
     --command "${COMMAND}" \
     --wait

--- a/test/integration/io_setup.sh
+++ b/test/integration/io_setup.sh
@@ -165,6 +165,13 @@ function io_setup::check_dstat() {
   echo "  Checking status"
   util::dstat_yaml_assert_field_equal "${dstat_output}" "[0].status" "SUCCESS"
 
+  if [[ "${DSUB_PROVIDER}" != "google" ]]; then
+    echo "  Checking script"
+    util::dstat_yaml_assert_field_equal "${dstat_output}" "[0].script-name" "script_io_test.sh"
+    local expected_script=$(cat "${SCRIPT_DIR}/script_io_test.sh")
+    util::dstat_yaml_assert_field_equal "${dstat_output}" "[0].script" "${expected_script}"
+  fi
+
   echo "  Checking datetime fields..."
   for field in 'create-time' 'end-time' 'start-time' 'last-update'; do
     if ! util::dstat_yaml_job_has_valid_datetime_field "${dstat_output}" "[0].${field}"; then

--- a/test/integration/retries_setup.sh
+++ b/test/integration/retries_setup.sh
@@ -64,6 +64,7 @@ function retries_setup::check_job_attr() {
       --format yaml)"
 
   # Check the expected values
+  echo "Checking expected values."
   local num=0
   local expected
   for expected in ${expected_values}; do
@@ -83,6 +84,7 @@ function retries_setup::check_job_attr() {
   done
 
   # Check that there were no extra attempts
+  echo "Checking that there are no unexpected attempts"
   local -r beyond="$(
       python "${SCRIPT_DIR}"/get_data_value.py \
         yaml "${dstat_out}" "[${num}].${attr}")"

--- a/test/integration/unit_flags.google-v2.sh
+++ b/test/integration/unit_flags.google-v2.sh
@@ -189,11 +189,14 @@ function test_accelerator_type_and_count() {
     --command 'echo "${TEST_NAME}"' \
     --regions us-central1 \
     --accelerator-type "nvidia-tesla-k80" \
+    --nvidia-driver-version "390.46" \
     --accelerator-count 2; then
 
     # Check that the output contains expected values
     assert_err_value_equals \
      "[0].pipeline.resources.virtualMachine.accelerators.[0].type" "nvidia-tesla-k80"
+    assert_err_value_equals \
+     "[0].pipeline.resources.virtualMachine.nvidiaDriverVersion" "390.46"
     assert_err_value_equals \
      "[0].pipeline.resources.virtualMachine.accelerators.[0].count" "2"
 
@@ -214,6 +217,8 @@ function test_no_accelerator_type_and_count() {
     # Check that the output contains expected values
     assert_err_value_equals \
      "[0].pipeline.resources.virtualMachine.accelerators" "None"
+    assert_err_value_equals \
+     "[0].pipeline.resources.virtualMachine.nvidiaDriverVersion" "None"
 
     test_passed "${subtest}"
   else

--- a/test/integration/unit_flags.google.sh
+++ b/test/integration/unit_flags.google.sh
@@ -77,7 +77,7 @@ function test_with_command() {
     'echo "${TEST_NAME}"'; then
 
     # Check that the output contains expected values
-    local expected=$(echo -e '#!/bin/bash\necho "${TEST_NAME}"')
+    local expected=$(echo -e '#!/usr/bin/env bash\necho "${TEST_NAME}"')
     assert_pipeline_environment_variable_equals \
       0 "_SCRIPT" "${expected}"
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -210,7 +210,8 @@ function get_test_providers() {
   fi
 
   case "${test_file}" in
-    e2e_requester_pays_buckets.sh)
+    e2e_requester_pays_buckets.sh | \
+    e2e_image.sh)
       echo -n "local google-v2"
       return
       ;;

--- a/test/unit/local_provider_test.py
+++ b/test/unit/local_provider_test.py
@@ -56,7 +56,8 @@ def _make_task(job_create_time, task_create_time, task_id):
       end_time=None,
       last_update=None,
       pid=None,
-      events=None)
+      events=None,
+      script=None)
 
 
 CREATE_TIME_1 = dsub_util.replace_timezone(


### PR DESCRIPTION
This release includes:
- "Retrying" output messages are more informative.
- `script` and `script-name` now appears in `dstat`.
- Docker entrypoints changed to '/usr/bin/env' to allow bash images to work.
- pyyaml version updated to latest version allowing Python3.7 support.
- `google-v2` provider updates:
  - `--nvidia-driver-version` parameter can now be used to specifiy the NVIDIA driver version to use when attaching an NVIDIA GPU accelerator.