### PR TITLE
Dstat action_id error fixed

### DIFF
--- a/dsub/providers/google_v2_operations.py
+++ b/dsub/providers/google_v2_operations.py
@@ -101,7 +101,7 @@ def get_actions(op):
 def get_action_by_id(op, action_id):
   """Return the operation's array of actions."""
   actions = get_actions(op)
-  if actions and 1 <= action_id < len(actions):
+  if actions and action_id and 1 <= action_id < len(actions):
     return actions[action_id - 1]
 
 


### PR DESCRIPTION
Running `dstat` throws the following error:
```
$ dstat --provider google-v2 --project <project-name>
Traceback (most recent call last):
  File "/home/vince/anaconda3/bin/dstat", line 11, in <module>
    load_entry_point('dsub==0.2.5', 'console_scripts', 'dstat')()
  File "/home/vince/anaconda3/lib/python3.7/site-packages/dsub-0.2.5-py3.7.egg/dsub/commands/dstat.py", line 504, in main
    for poll_event_tasks in job_producer:
  File "/home/vince/anaconda3/lib/python3.7/site-packages/dsub-0.2.5-py3.7.egg/dsub/commands/dstat.py", line 588, in dstat_job_producer
    formatted_tasks.append(_prepare_row(task, full_output, summary_output))
  File "/home/vince/anaconda3/lib/python3.7/site-packages/dsub-0.2.5-py3.7.egg/dsub/commands/dstat.py", line 334, in _prepare_row
    value = task.get_field(key, default)
  File "/home/vince/anaconda3/lib/python3.7/site-packages/dsub-0.2.5-py3.7.egg/dsub/providers/google_v2.py", line 1328, in get_field
    msg, action = self._operation_status_message()
  File "/home/vince/anaconda3/lib/python3.7/site-packages/dsub-0.2.5-py3.7.egg/dsub/providers/google_v2.py", line 1211, in _operation_status_message
    action = google_v2_operations.get_action_by_id(self._op, action_id)
  File "/home/vince/anaconda3/lib/python3.7/site-packages/dsub-0.2.5-py3.7.egg/dsub/providers/google_v2_operations.py", line 104, in get_action_by_id
    if actions and 1 <= action_id < len(actions):
TypeError: '<=' not supported between instances of 'int' and 'NoneType'
```

Checking if `action_id` is `None` resolves the issue but I'm not sure if that's the best way to deal with this. The error comes from [this line](https://github.com/DataBiosphere/dsub/blob/6e677aec811761600eb2170612467784bdf78417/dsub/providers/google_v2.py#L1210), because there's no `actionId` in the event description. Also, searching for `actionId` in the whole repo shows 2 places where it is used, but it doesn't seem to be set anywhere.

Please let me know if you need more info or you want me to investigate this a bit further.

Cheers