### PR TITLE
Str decode error fixed

### DIFF
--- a/dsub/providers/local.py
+++ b/dsub/providers/local.py
@@ -634,7 +634,7 @@ class LocalJobProvider(base.JobProvider):
   def _get_log_detail_from_task_dir(self, task_dir):
     try:
       with open(os.path.join(task_dir, 'runner-log.txt'), 'r') as f:
-        return [line.decode('utf-8') for line in f.read().splitlines()]
+        return [line for line in f.read().splitlines()]
     except (IOError, OSError):
       return None
 


### PR DESCRIPTION
Running a job with `--provider local` throws the following error:

```
Job: proc-jobs.--vince--190218-160217-159815
Launched job-id: proc-jobs.--vince--190218-160217-159815
2 task(s)
To check the status, run:
  dstat --provider local --jobs 'proc-jobs.--vince--190218-160217-159815' --status '*'
To cancel the job, run:
  ddel --provider local --jobs 'proc-jobs.--vince--190218-160217-159815'
Waiting for job to complete...
Waiting for: proc-jobs.--vince--190218-160217-159815.
Traceback (most recent call last):
  File "/home/vince/anaconda3/bin/dsub", line 11, in <module>
    load_entry_point('dsub==0.2.5', 'console_scripts', 'dsub')()
  File "/home/vince/anaconda3/lib/python3.7/site-packages/dsub-0.2.5-py3.7.egg/dsub/commands/dsub.py", line 933, in main
    dsub_main(prog, argv)
  File "/home/vince/anaconda3/lib/python3.7/site-packages/dsub-0.2.5-py3.7.egg/dsub/commands/dsub.py", line 922, in dsub_main
    launched_job = run_main(args)
  File "/home/vince/anaconda3/lib/python3.7/site-packages/dsub-0.2.5-py3.7.egg/dsub/commands/dsub.py", line 1004, in run_main
    disable_warning=True)
  File "/home/vince/anaconda3/lib/python3.7/site-packages/dsub-0.2.5-py3.7.egg/dsub/commands/dsub.py", line 1118, in run
    poll_interval, False)
  File "/home/vince/anaconda3/lib/python3.7/site-packages/dsub-0.2.5-py3.7.egg/dsub/commands/dsub.py", line 646, in _wait_after
    jobs_left = _wait_for_any_job(provider, job_ids_to_check, poll_interval)
  File "/home/vince/anaconda3/lib/python3.7/site-packages/dsub-0.2.5-py3.7.egg/dsub/commands/dsub.py", line 856, in _wait_for_any_job
    tasks = provider.lookup_job_tasks({'*'}, job_ids=job_ids)
  File "/home/vince/anaconda3/lib/python3.7/site-packages/dsub-0.2.5-py3.7.egg/dsub/providers/local.py", line 530, in lookup_job_tasks
    task = self._get_task_from_task_dir(j, u, task_id, task_attempt)
  File "/home/vince/anaconda3/lib/python3.7/site-packages/dsub-0.2.5-py3.7.egg/dsub/providers/local.py", line 684, in _get_task_from_task_dir
    log_detail = self._get_log_detail_from_task_dir(task_dir)
  File "/home/vince/anaconda3/lib/python3.7/site-packages/dsub-0.2.5-py3.7.egg/dsub/providers/local.py", line 637, in _get_log_detail_from_task_dir
    return [line.decode('utf-8') for line in f.read().splitlines()]
  File "/home/vince/anaconda3/lib/python3.7/site-packages/dsub-0.2.5-py3.7.egg/dsub/providers/local.py", line 637, in <listcomp>
    return [line.decode('utf-8') for line in f.read().splitlines()]
AttributeError: 'str' object has no attribute 'decode'
```

Let me know if you need more info.

Cheers