### PR TITLE
Added support for disk type for data disks.

### DIFF
--- a/dsub/commands/dsub.py
+++ b/dsub/commands/dsub.py
@@ -480,6 +480,10 @@ def _parse_arguments(prog, argv):
           GPU libraries contained in the container being executed, and must be
           one of the drivers hosted in the nvidia-drivers-us-public bucket on
           Google Cloud Storage.""")
+  google_v2.add_argument(
+      '--disk-type',
+      help="""The disk type to use for the data disk"""
+  )
 
   args = provider_base.parse_args(
       parser, {
@@ -534,7 +538,8 @@ def _get_job_resources(args):
       nvidia_driver_version=args.nvidia_driver_version,
       timeout=timeout,
       log_interval=log_interval,
-      ssh=args.ssh)
+      ssh=args.ssh,
+      disk_type=args.disk_type)
 
 
 def _get_job_metadata(provider, user_id, job_name, script, task_ids,

--- a/dsub/lib/job_model.py
+++ b/dsub/lib/job_model.py
@@ -69,6 +69,7 @@ DEFAULT_DISK_SIZE = 200
 DEFAULT_BOOT_DISK_SIZE = 10
 DEFAULT_MOUNTED_DISK_SIZE = 10
 DEFAULT_PREEMPTIBLE = False
+DEFAULT_DISK_TYPE = 'pd-standard'
 
 # Users may specify their own labels, however dsub also uses an implicit set of
 # labels (in the google provider). Reserve these labels such that users do
@@ -377,7 +378,7 @@ class Resources(
         'preemptible', 'image', 'logging', 'logging_path', 'regions', 'zones',
         'scopes', 'keep_alive', 'cpu_platform', 'network', 'subnetwork',
         'use_private_address', 'accelerator_type', 'accelerator_count',
-        'nvidia_driver_version', 'timeout', 'log_interval', 'ssh'
+        'nvidia_driver_version', 'timeout', 'log_interval', 'ssh','disk_type'
     ])):
   """Job resource parameters related to CPUs, memory, and disk.
 
@@ -407,6 +408,7 @@ class Resources(
     timeout (string): The max amount of time to give the pipeline to complete.
     log_interval (string): The amount of time to sleep between log uploads.
     ssh (bool): Start an SSH container in the background.
+    disk_type (string): disk_type for the data disk
   """
   __slots__ = ()
 
@@ -433,13 +435,14 @@ class Resources(
               nvidia_driver_version=None,
               timeout=None,
               log_interval=None,
-              ssh=None):
+              ssh=None,
+              disk_type=None):
     return super(Resources, cls).__new__(
         cls, min_cores, min_ram, machine_type, disk_size, boot_disk_size,
         preemptible, image, logging, logging_path, regions, zones, scopes,
         keep_alive, cpu_platform, network, subnetwork, use_private_address,
         accelerator_type, accelerator_count, nvidia_driver_version, timeout,
-        log_interval, ssh)
+        log_interval, ssh,disk_type)
 
 
 def ensure_job_params_are_complete(job_params):

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -631,7 +631,8 @@ class GoogleV2JobProvider(base.JobProvider):
         google_v2_pipelines.build_disk(
             name=disk.name.replace('_', '-'),  # Underscores not allowed
             size_gb=disk.disk_size or job_model.DEFAULT_MOUNTED_DISK_SIZE,
-            source_image=disk.value) for disk in persistent_disk_mount_params
+            source_image=disk.value,
+            disk_type=disk.type or job_model.DEFAULT_DISK_TYPE) for disk in persistent_disk_mount_params
     ]
     persistent_disk_mounts = [
         google_v2_pipelines.build_mount(
@@ -789,7 +790,7 @@ class GoogleV2JobProvider(base.JobProvider):
     # Prepare the VM (resources) configuration
     disks = [
         google_v2_pipelines.build_disk(
-            _DATA_DISK_NAME, job_resources.disk_size, source_image=None)
+            _DATA_DISK_NAME, job_resources.disk_size, source_image=None, disk_type=job_resources.disk_type or job_model.DEFAULT_DISK_TYPE)
     ]
     disks.extend(persistent_disks)
     network = google_v2_pipelines.build_network(

--- a/dsub/providers/google_v2_pipelines.py
+++ b/dsub/providers/google_v2_pipelines.py
@@ -27,10 +27,11 @@ def build_network(name, subnetwork, use_private_address):
   }
 
 
-def build_disk(name, size_gb, source_image):
+def build_disk(name, size_gb, source_image,disk_type):
   return {
       'name': name,
       'sizeGb': size_gb,
+      'type': disk_type,
       'sourceImage': source_image,
   }
 


### PR DESCRIPTION
This would fix #73 

While I agree that in most cases adding SSD will only deliver marginal gains there are some vendor provided containers that are providing minimum requirements of SSD. By adding disk type support it limits confusion as to whether these types of workloads can be used via dsub.