### PR TITLE
Add a verbose mode option flag to dsub

### DIFF
--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.3.3'
+DSUB_VERSION = '0.3.4.dev0'

--- a/dsub/commands/dsub.py
+++ b/dsub/commands/dsub.py
@@ -245,6 +245,11 @@ def _parse_arguments(prog, argv):
           Docker image service. The pipeline must have READ access to the
           image.""")
   parser.add_argument(
+      '--verbose',
+      default=False,
+      action='store_true',
+      help='Enable verbose mode logging.')
+  parser.add_argument(
       '--dry-run',
       default=False,
       action='store_true',


### PR DESCRIPTION
I noticed that the providers have a `verbose` mode object variable, and that object variable is potentially set via the `args` :

```
$ git grep "getattr(args, 'verbose'"
dsub/providers/provider_base.py:        getattr(args, 'verbose', False),
dsub/providers/provider_base.py:        getattr(args, 'verbose', False), getattr(args, 'dry_run', False),
```

but there was no way to toggle that option via the CLI.  This change adds a `--verbose` option to the command line.