### PR TITLE
PR for 0.3.4 release

### DIFF
--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.3.3'
+DSUB_VERSION = '0.3.4.dev0'

--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.3.4.dev0'
+DSUB_VERSION = '0.3.4'

--- a/dsub/lib/dsub_util.py
+++ b/dsub/lib/dsub_util.py
@@ -27,9 +27,10 @@ import sys
 from apiclient import discovery
 from apiclient import errors
 from apiclient.http import MediaIoBaseDownload
-import oauth2client.client
 import retrying
 import six
+
+import google.auth
 
 
 # this is the Job ID for jobs that are skipped.
@@ -131,8 +132,7 @@ def compact_interval_string(value_list):
 def _get_storage_service(credentials):
   """Get a storage client using the provided credentials or defaults."""
   if credentials is None:
-    credentials = oauth2client.client.GoogleCredentials.get_application_default(
-    )
+    credentials, _ = google.auth.default()
   return discovery.build('storage', 'v1', credentials=credentials)
 
 
@@ -141,7 +141,7 @@ def _retry_storage_check(exception):
   now = datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
   print_error(
       '%s: Exception %s: %s' % (now, type(exception).__name__, str(exception)))
-  return isinstance(exception, oauth2client.client.AccessTokenRefreshError)
+  return isinstance(exception, google.auth.exceptions.RefreshError)
 
 
 # Exponential backoff retrying downloads of GCS object chunks.

--- a/dsub/lib/param_util.py
+++ b/dsub/lib/param_util.py
@@ -517,6 +517,12 @@ def tasks_file_to_task_descriptors(tasks, retries, input_file_param_util,
   task_min = tasks.get('min')
   task_max = tasks.get('max')
 
+  # First check for any empty lines
+  param_file = dsub_util.load_file(path)
+  if any([not line for line in param_file]):
+    raise ValueError('Blank line(s) found in {}'.format(path))
+  param_file.close()
+
   # Load the file and set up a Reader that tokenizes the fields
   param_file = dsub_util.load_file(path)
   reader = csv.reader(param_file, delimiter='\t')
@@ -537,8 +543,9 @@ def tasks_file_to_task_descriptors(tasks, retries, input_file_param_util,
       continue
 
     if len(row) != len(job_params):
-      dsub_util.print_error('Unexpected number of fields %s vs %s: line %s' %
-                            (len(row), len(job_params), reader.line_num))
+      raise ValueError(
+          'Unexpected number of fields {} vs {}: in {} line {}'.format(
+              len(row), len(job_params), path, reader.line_num))
 
     # Each row can contain "envs", "inputs", "outputs"
     envs = set()

--- a/dsub/providers/google_base.py
+++ b/dsub/providers/google_base.py
@@ -33,10 +33,12 @@ import apiclient.discovery
 import apiclient.errors
 from httplib2 import ServerNotFoundError
 from ..lib import job_model
-import oauth2client.client
 import pytz
 import retrying
 from six.moves import range
+
+import google.auth
+
 
 # The google v1 provider directly added the bigquery scope, but the v1alpha2
 # API automatically added:
@@ -505,7 +507,7 @@ def retry_api_check(exception, verbose):
       _print_retry_error(exception, verbose)
       return True
 
-  if isinstance(exception, oauth2client.client.AccessTokenRefreshError):
+  if isinstance(exception, google.auth.exceptions.RefreshError):
     _print_retry_error(exception, verbose)
     return True
 
@@ -587,8 +589,7 @@ def setup_service(api_name, api_version, credentials=None):
     A configured Google Genomics API client with appropriate credentials.
   """
   if not credentials:
-    credentials = oauth2client.client.GoogleCredentials.get_application_default(
-    )
+    credentials, _ = google.auth.default()
   return apiclient.discovery.build(
       api_name, api_version, credentials=credentials)
 

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -49,13 +49,9 @@ _SUPPORTED_LOGGING_PROVIDERS = _SUPPORTED_FILE_PROVIDERS
 _SUPPORTED_INPUT_PROVIDERS = _SUPPORTED_FILE_PROVIDERS
 _SUPPORTED_OUTPUT_PROVIDERS = _SUPPORTED_FILE_PROVIDERS
 
-# Action steps that interact with GCS need gsutil.
-# Use the 'slim' variant of the cloud-sdk Docker image as it is much smaller.
-_CLOUD_SDK_IMAGE = 'google/cloud-sdk:slim'
-
-# The prepare step needs Python.
-# Use the 'slim' variant of the python Docker image as it is much smaller.
-_PYTHON_IMAGE = 'python:2.7-slim'
+# Action steps that interact with GCS need gsutil and Python.
+# Use the 'slim' variant of the cloud-sdk image as it is much smaller.
+_CLOUD_SDK_IMAGE = 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
 
 # This image is for an optional ssh container.
 _SSH_IMAGE = 'gcr.io/cloud-genomics-pipelines/tools'
@@ -765,7 +761,7 @@ class GoogleV2JobProvider(base.JobProvider):
     actions.append(
         google_v2_pipelines.build_action(
             name='prepare',
-            image_uri=_PYTHON_IMAGE,
+            image_uri=_CLOUD_SDK_IMAGE,
             mounts=[mnt_datadisk],
             environment=prepare_env,
             entrypoint='/bin/bash',

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -51,7 +51,7 @@ _SUPPORTED_OUTPUT_PROVIDERS = _SUPPORTED_FILE_PROVIDERS
 
 # Action steps that interact with GCS need gsutil and Python.
 # Use the 'slim' variant of the cloud-sdk image as it is much smaller.
-_CLOUD_SDK_IMAGE = 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+_CLOUD_SDK_IMAGE = 'gcr.io/google.com/cloudsdktool/cloud-sdk:264.0.0-slim'
 
 # This image is for an optional ssh container.
 _SSH_IMAGE = 'gcr.io/cloud-genomics-pipelines/tools'

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -468,8 +468,7 @@ class GoogleV2BatchHandler(object):
 class GoogleV2JobProvider(base.JobProvider):
   """dsub provider implementation managing Jobs on Google Cloud."""
 
-  def __init__(self, verbose, dry_run, project, credentials=None):
-    self._verbose = verbose
+  def __init__(self, dry_run, project, credentials=None):
     self._dry_run = dry_run
 
     self._project = project
@@ -887,8 +886,7 @@ class GoogleV2JobProvider(base.JobProvider):
     google_base_api = google_base.Api(verbose=True)
     operation = google_base_api.execute(
         self._service.pipelines().run(body=request))
-    if self._verbose:
-      print('Launched operation {}'.format(operation['name']))
+    print('Provider internal-id (operation): {}'.format(operation['name']))
 
     return GoogleOperation(operation).get_field('task-id')
 

--- a/dsub/providers/provider_base.py
+++ b/dsub/providers/provider_base.py
@@ -45,8 +45,7 @@ def get_provider(args, resources):
         getattr(args, 'dry_run', False), args.project)
   elif provider == 'google-v2':
     return google_v2.GoogleV2JobProvider(
-        getattr(args, 'verbose', False), getattr(args, 'dry_run', False),
-        args.project)
+        getattr(args, 'dry_run', False), args.project)
   elif provider == 'local':
     return local.LocalJobProvider(resources)
   elif provider == 'test-fails':

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ setup(
 
         # dependencies for test code
         'parameterized',
+        'mock',
     ],
 
     # Define a test suite for Python unittests only.

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
     install_requires=[
         # dependencies for dsub, ddel, dstat
         'google-api-python-client',
-        'oauth2client',
+        'google-auth',
         'python-dateutil',
         'pytz',
         'pyyaml',

--- a/test/integration/e2e_python_api.py
+++ b/test/integration/e2e_python_api.py
@@ -46,7 +46,7 @@ def get_dsub_provider():
   elif test.DSUB_PROVIDER == 'google':
     return google.GoogleJobProvider(False, False, test.PROJECT_ID)
   elif test.DSUB_PROVIDER == 'google-v2':
-    return google_v2.GoogleV2JobProvider(False, False, test.PROJECT_ID)
+    return google_v2.GoogleV2JobProvider(False, test.PROJECT_ID)
   else:
     print('Invalid provider specified.', file=sys.stderr)
     sys.exit(1)


### PR DESCRIPTION
This release includes:
- `dsub`
  - Explicitly reject launching jobs if blank lines found in tasks file (instead of erroring)
- `google-v2` provider updates:
  - Expose the Pipelines API operation id in dsub launch stderr output.
  - Replace `oauth2lib` with `google-auth`
  - Update cloud sdk image to a GCR hosted one, `gcr.io/google.com/cloudsdktool/cloud-sdk:264.0.0-slim`. This version was specifically chosen as the next version updates `gsutil` from 4.42 to 4.43. 4.43 includes undesired changes to `gsutil cp`. See [gsutil's changelogs](https://github.com/GoogleCloudPlatform/gsutil/blob/master/CHANGES.md) for details.
- Test updates:
  - Use fake time in `retrying_test`.