### PR TITLE
PR for 0.3.9 release

### DIFF
--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.3.9.dev0'
+DSUB_VERSION = '0.3.9'

--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.3.8'
+DSUB_VERSION = '0.3.9.dev0'

--- a/dsub/commands/dsub.py
+++ b/dsub/commands/dsub.py
@@ -1170,8 +1170,8 @@ def run(provider,
     script = job_model.Script(command_name, '#!/usr/bin/env bash\n' + command)
   elif script:
     # Read the script file
-    script_file = dsub_util.load_file(script)
-    script = job_model.Script(os.path.basename(script), script_file.read())
+    script_file_contents = dsub_util.load_file(script)
+    script = job_model.Script(os.path.basename(script), script_file_contents)
   else:
     raise ValueError('One of --command or a script name must be supplied')
 

--- a/dsub/commands/dsub.py
+++ b/dsub/commands/dsub.py
@@ -402,8 +402,8 @@ def _parse_arguments(prog, argv):
   # Shared between the "google-cls-v2" and "google-v2" providers
   google_common = parser.add_argument_group(
       title='google-common',
-      description="""Options common to the "google", "google-cls-v2", and
-        "google-v2" providers""")
+      description="""Options common to the "google-cls-v2" and "google-v2"
+        providers""")
   google_common.add_argument(
       '--project', help='Cloud project ID in which to run the job')
   google_common.add_argument(
@@ -453,78 +453,74 @@ def _parse_arguments(prog, argv):
       '--credentials-file',
       type=str,
       help='Path to a local file with JSON credentials for a service account.')
-
-  google_v2 = parser.add_argument_group(
-      title='"google-v2" provider options',
-      description='See also the "google-common" options listed above')
-  google_v2.add_argument(
+  google_common.add_argument(
       '--regions',
       nargs='+',
       help="""List of Google Compute Engine regions.
           Only one of --zones and --regions may be specified.""")
-  google_v2.add_argument(
+  google_common.add_argument(
       '--machine-type', help='Provider-specific machine type (default: None)')
-  google_v2.add_argument(
+  google_common.add_argument(
       '--cpu-platform',
       help="""The CPU platform to request. Supported values can be found at
       https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform
       (default: None)""")
-  google_v2.add_argument(
+  google_common.add_argument(
       '--network',
       help="""The Compute Engine VPC network name to attach the VM's network
           interface to. The value will be prefixed with global/networks/ unless
           it contains a /, in which case it is assumed to be a fully specified
           network resource URL. (default: None)""")
-  google_v2.add_argument(
+  google_common.add_argument(
       '--subnetwork',
       help="""The name of the Compute Engine subnetwork to attach the instance
           to. (default: None)""")
-  google_v2.add_argument(
+  google_common.add_argument(
       '--use-private-address',
       default=False,
       action='store_true',
       help="""If set to true, do not attach a public IP address to the VM.
       (default: False)""")
-  google_v2.add_argument(
+  google_common.add_argument(
       '--timeout',
       help="""The maximum amount of time to give the task to complete.
           This includes the time spent waiting for a worker to be allocated.
           Time can be listed using a number followed by a unit. Supported units
           are s (seconds), m (minutes), h (hours), d (days), w (weeks). The
           provider-specific default is 7 days. Example: '7d' (7 days).""")
-  google_v2.add_argument(
+  google_common.add_argument(
       '--log-interval',
       help="""The amount of time to sleep between copies of log files from
           the task to the logging path.
           Time can be listed using a number followed by a unit. Supported units
           are s (seconds), m (minutes), h (hours).
           Example: '5m' (5 minutes). Default is '1m'.""")
-  google_v2.add_argument(
+  google_common.add_argument(
       '--ssh',
       default=False,
       action='store_true',
       help="""If set to true, start an ssh container in the background
           to allow you to log in using SSH and debug in real time.
           (default: False)""")
-  google_v2.add_argument(
+  google_common.add_argument(
       '--nvidia-driver-version',
       help="""The NVIDIA driver version to use when attaching an NVIDIA GPU
           accelerator. The version specified here must be compatible with the
           GPU libraries contained in the container being executed, and must be
           one of the drivers hosted in the nvidia-drivers-us-public bucket on
           Google Cloud Storage. (default: None)""")
-  google_v2.add_argument(
+  google_common.add_argument(
       '--service-account',
       type=str,
       help="""Email address of the service account to be authorized on the
           Compute Engine VM for each job task. If not specified, the default
           Compute Engine service account for the project will be used.""")
-  google_v2.add_argument(
+  google_common.add_argument(
       '--disk-type',
       help="""
           The disk type to use for the data disk. Valid values are pd-standard
           pd-ssd and local-ssd. The default value is pd-standard.""")
-  google_v2.add_argument(
+  google_common.add_argument(
       '--enable-stackdriver-monitoring',
       default=False,
       action='store_true',

--- a/dsub/lib/dsub_util.py
+++ b/dsub/lib/dsub_util.py
@@ -16,8 +16,8 @@
 
 from __future__ import print_function
 
-from contextlib import contextmanager
-from datetime import datetime
+import contextlib
+import datetime
 import fnmatch
 import io
 import os
@@ -54,7 +54,7 @@ class _Printer(object):
     self._fileobj.write(buf)
 
 
-@contextmanager
+@contextlib.contextmanager
 def replace_print(fileobj=sys.stderr):
   """Sys.out replacer, by default with stderr.
 
@@ -142,7 +142,7 @@ def _get_storage_service(credentials):
 
 def _retry_storage_check(exception):
   """Return True if we should retry, False otherwise."""
-  now = datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
+  now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
   print_error(
       '%s: Exception %s: %s' % (now, type(exception).__name__, str(exception)))
   return isinstance(exception, google.auth.exceptions.RefreshError)
@@ -184,7 +184,7 @@ def _load_file_from_gcs(gcs_file_path, credentials=None):
   filevalue = file_handle.getvalue()
   if not isinstance(filevalue, six.string_types):
     filevalue = filevalue.decode()
-  return six.StringIO(filevalue)
+  return filevalue
 
 
 def load_file(file_path, credentials=None):
@@ -196,13 +196,13 @@ def load_file(file_path, credentials=None):
     credentials: Optional credential to be used to load the file from gcs.
 
   Returns:
-    A python File object if loading file from local or a StringIO object if
-    loading from gcs.
+    The contents of the file as a string.
   """
   if file_path.startswith('gs://'):
     return _load_file_from_gcs(file_path, credentials)
   else:
-    return open(file_path, 'r')
+    with open(file_path, 'r') as f:
+      return f.read()
 
 
 # Exponential backoff retrying downloads of GCS object chunks.

--- a/dsub/lib/job_model.py
+++ b/dsub/lib/job_model.py
@@ -54,12 +54,10 @@ API to set each of the resource fields at the task level.
 from __future__ import print_function
 
 import collections
-import datetime
 import re
 import string
 
 from . import dsub_util
-from dateutil.tz import tzlocal
 import pytz
 import yaml
 
@@ -788,86 +786,6 @@ class JobDescriptor(object):
     return mounts
 
   @classmethod
-  def _from_yaml_v0(cls, job):
-    """Populate a JobDescriptor from the local provider's original meta.yaml.
-
-    The local job provider had the first incarnation of a YAML file for each
-    task. That idea was extended here in the JobDescriptor and the local
-    provider adopted the JobDescriptor.to_yaml() call to write its meta.yaml.
-
-    The JobDescriptor.from_yaml() detects if it receives a local provider's
-    "v0" meta.yaml and calls this function.
-
-    Args:
-      job: an object produced from decoding meta.yaml.
-
-    Returns:
-      A JobDescriptor populated as best we can from the old meta.yaml.
-    """
-
-    # The v0 meta.yaml only contained:
-    #   create-time, job-id, job-name, logging, task-id
-    #   labels, envs, inputs, outputs
-    # It did NOT contain user-id.
-    # dsub-version might be there as a label.
-
-    job_metadata = {}
-    for key in ['job-id', 'job-name', 'create-time']:
-      job_metadata[key] = job.get(key)
-
-    # Make sure that create-time string is turned into a datetime
-    job_metadata['create-time'] = dsub_util.replace_timezone(
-        datetime.datetime.strptime(job['create-time'], '%Y-%m-%d %H:%M:%S.%f'),
-        tzlocal())
-
-    # The v0 meta.yaml contained a "logging" field which was the task-specific
-    # logging path. It did not include the actual "--logging" value the user
-    # specified.
-    job_resources = Resources()
-
-    # The v0 meta.yaml represented a single task.
-    # It did not distinguish whether params were job params or task params.
-    # We will treat them as either all job params or all task params, based on
-    # whether the task-id is empty or an integer value.
-    #
-    # We also cannot distinguish whether inputs/outputs were recursive or not.
-    # Just treat them all as non-recursive.
-    params = {}
-
-    # The dsub-version may be in the meta.yaml as a label. If so remove it
-    # and set it as a top-level job metadata value.
-    labels = job.get('labels', {})
-    if 'dsub-version' in labels:
-      job_metadata['dsub-version'] = labels['dsub-version']
-      del labels['dsub-version']
-    params['labels'] = cls._label_params_from_dict(labels)
-
-    params['envs'] = cls._env_params_from_dict(job.get('envs', {}))
-    params['inputs'] = cls._input_file_params_from_dict(
-        job.get('inputs', {}), False)
-    params['outputs'] = cls._output_file_params_from_dict(
-        job.get('outputs', {}), False)
-
-    if job.get('task-id') is None:
-      job_params = params
-      task_metadata = {'task-id': None}
-      task_params = {}
-    else:
-      job_params = {}
-      task_metadata = {'task-id': str(job.get('task-id'))}
-      task_params = params
-
-    task_resources = Resources(logging_path=job.get('logging'))
-
-    task_descriptors = [
-        TaskDescriptor.get_complete_descriptor(task_metadata, task_params,
-                                               task_resources)
-    ]
-
-    return JobDescriptor.get_complete_descriptor(
-        job_metadata, job_params, job_resources, task_descriptors)
-
-  @classmethod
   def from_yaml(cls, yaml_string):
     """Populate and return a JobDescriptor from a YAML string."""
     try:
@@ -875,13 +793,6 @@ class JobDescriptor(object):
     except AttributeError:
       # For installations that cannot update their PyYAML version
       job = yaml.load(yaml_string)
-
-    # If the YAML does not contain a top-level dsub version, then assume that
-    # the string is coming from the local provider, reading an old version of
-    # its meta.yaml.
-    dsub_version = job.get('dsub-version')
-    if not dsub_version:
-      return cls._from_yaml_v0(job)
 
     job_metadata = {}
     for key in [

--- a/dsub/lib/param_util.py
+++ b/dsub/lib/param_util.py
@@ -519,13 +519,12 @@ def tasks_file_to_task_descriptors(tasks, retries, input_file_param_util,
 
   # First check for any empty lines
   param_file = dsub_util.load_file(path)
-  if any([not line for line in param_file]):
+  param_file_lines = param_file.splitlines()
+  if any([not line for line in param_file_lines]):
     raise ValueError('Blank line(s) found in {}'.format(path))
-  param_file.close()
 
-  # Load the file and set up a Reader that tokenizes the fields
-  param_file = dsub_util.load_file(path)
-  reader = csv.reader(param_file, delimiter='\t')
+  # Set up a Reader that tokenizes the fields
+  reader = csv.reader(param_file_lines, delimiter='\t')
 
   # Read the first line and extract the parameters
   header = six.advance_iterator(reader)

--- a/dsub/providers/google_v2_base.py
+++ b/dsub/providers/google_v2_base.py
@@ -51,7 +51,7 @@ _SUPPORTED_OUTPUT_PROVIDERS = _SUPPORTED_FILE_PROVIDERS
 
 # Action steps that interact with GCS need gsutil and Python.
 # Use the 'slim' variant of the cloud-sdk image as it is much smaller.
-_CLOUD_SDK_IMAGE = 'gcr.io/google.com/cloudsdktool/cloud-sdk:264.0.0-slim'
+_CLOUD_SDK_IMAGE = 'gcr.io/google.com/cloudsdktool/cloud-sdk:294.0.0-slim'
 
 # This image is for an optional ssh container.
 _SSH_IMAGE = 'gcr.io/cloud-genomics-pipelines/tools'
@@ -110,9 +110,6 @@ _GSUTIL_CP_FN = textwrap.dedent("""\
       if (( attempt < 3 )); then
         log_warning "Sleeping 10s before the next attempt of failed gsutil command"
         log_warning "gsutil ${headers} ${user_project_flag} -mq cp \"${src}\" \"${dst}\""
-        # Workaround for gsutil/gcloud issue that prevents re-authentication
-        # See https://github.com/googlegenomics/pipelines-tools/commit/464fd9c4a894b9144944459e47b64871aebd033a
-        rm -f "${HOME}/.config/gcloud/gce"
         sleep 10s
       fi
     done
@@ -164,9 +161,6 @@ _GSUTIL_RSYNC_FN = textwrap.dedent("""\
       if (( attempt < 3 )); then
         log_warning "Sleeping 10s before the next attempt of failed gsutil command"
         log_warning "gsutil ${user_project_flag} -mq rsync -r \"${src}\" \"${dst}\""
-        # Workaround for gsutil issue that prevents re-authentication
-        # See https://github.com/googlegenomics/pipelines-tools/commit/464fd9c4a894b9144944459e47b64871aebd033a
-        rm -f "${HOME}/.config/gcloud/gce"
         sleep 10s
       fi
     done

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,11 @@ _DEPENDENCIES = [
     # dependencies for dsub, ddel, dstat
     # Pin to known working versions to prevent episodic breakage from library
     # version mismatches.
-    # This version list generated: 05/19/2020
+    # This version list generated: 06/22/2020
 
     # direct dependencies
     'google-api-python-client<=1.8.3',
-    'google-auth<=1.15.0',
+    'google-auth<=1.18.0',
     'python-dateutil<=2.8.1',
     'pytz<=2019.3',
     'pyyaml<=5.2',
@@ -29,6 +29,7 @@ _DEPENDENCIES = [
 
     # downstream dependencies
     'funcsigs<=1.0.2',
+    'google-api-core<=1.21.0',
     'google-auth-httplib2<=0.0.3',
     'httplib2<=0.17.3',
     'pyasn1<=0.4.8',

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -215,14 +215,7 @@ function get_test_providers() {
     return
   fi
 
- case "${test_file}" in
-    e2e_error.sh)
-      local all_provider_list="${DSUB_PROVIDER:-local}"
-      ;;
-    *)
-      local all_provider_list="${DSUB_PROVIDER:-local google-v2 google-cls-v2}"
-      ;;
-  esac
+  local all_provider_list="${DSUB_PROVIDER:-local google-v2 google-cls-v2}"
 
   echo -n "${all_provider_list}"
 }


### PR DESCRIPTION
This release includes:
- `dsub`
  - Update version of cloudsdk docker image. Revert workaround for gsutil/gcloud bug, which should now be fixed in the updated image.
  - Update `google-auth` to 1.18.0 and pin `google-api-core` to 1.21.0
  - Remove all characters that are not a letter, number, or underscore when creating a name for command.
  - Move `google_v2` arguments to `google_common` in the `--help` text.
  - Add a section for Google provider-specific command-line flags.
- Testing updates:
  - Re-enable the test `e2e_errors.sh` for all providers.
  - Add unit test for retrying BrokenPipeError
  - Fix ResourceWarning when running python unit tests.