### PR TITLE
PR for 0.4.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.7"
   - "3.7"
 # command to install dependencies
 install: "python setup.py install"

--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ The steps for getting started differ slightly as indicated in the steps below:
 
      [Enable the Cloud Life Sciences, Storage, and Compute APIs](https://console.cloud.google.com/flows/enableapi?apiid=lifesciences.googleapis.com,storage_component,compute_component&redirect=https://console.cloud.google.com)
 
-
 1.  [Install the Google Cloud SDK](https://cloud.google.com/sdk/) and run
 
         gcloud init
@@ -188,28 +187,28 @@ The steps for getting started differ slightly as indicated in the steps below:
 
     - For the `v2alpha1` API (provider: `google-v2`):
 
-        dsub \
-          --provider google-v2 \
-          --project my-cloud-project \
-          --regions us-central1 \
-          --logging gs://my-bucket/logging/ \
-          --output OUT=gs://my-bucket/output/out.txt \
-          --command 'echo "Hello World" > "${OUT}"' \
-          --wait
+            dsub \
+              --provider google-v2 \
+              --project my-cloud-project \
+              --regions us-central1 \
+              --logging gs://my-bucket/logging/ \
+              --output OUT=gs://my-bucket/output/out.txt \
+              --command 'echo "Hello World" > "${OUT}"' \
+              --wait
 
     Change `my-cloud-project` to your Google Cloud project, and `my-bucket` to
     the bucket you created above.
 
     - For the `v2beta` API (provider: `google-cls-v2`):
 
-        dsub \
-          --provider google-cls-v2 \
-          --project my-cloud-project \
-          --regions us-central1 \
-          --logging gs://my-bucket/logging/ \
-          --output OUT=gs://my-bucket/output/out.txt \
-          --command 'echo "Hello World" > "${OUT}"' \
-          --wait
+            dsub \
+              --provider google-cls-v2 \
+              --project my-cloud-project \
+              --regions us-central1 \
+              --logging gs://my-bucket/logging/ \
+              --output OUT=gs://my-bucket/output/out.txt \
+              --command 'echo "Hello World" > "${OUT}"' \
+              --wait
 
     Change `my-cloud-project` to your Google Cloud project, and `my-bucket` to
     the bucket you created above.

--- a/README.md
+++ b/README.md
@@ -291,8 +291,12 @@ working with input and output files and folders.
 
 ### Selecting a Docker image
 
-By default, dsub uses a stock Ubuntu image. You can change the image
-by passing the `--image` flag.
+To get started more easily, `dsub` uses a stock Ubuntu Docker image.
+This default image may change at any time in future releases, so for
+reproducible production workflows, you should always specify the image
+explicitly.
+
+You can change the image by passing the `--image` flag.
 
     dsub \
         ... \
@@ -301,6 +305,10 @@ by passing the `--image` flag.
 
 Note: your `--image` must include the
 [Bash](https://en.wikipedia.org/wiki/Bash_(Unix_shell)) shell interpreter.
+
+For more information on using the
+`--image` flag, see the
+[image section in Scripts, Commands, and Docker](https://github.com/DataBiosphere/dsub/blob/master/docs/code.md#--image-docker-image)
 
 ### Passing parameters to your script
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,12 @@ install from [github](https://github.com/DataBiosphere/dsub).
 
 ### Sunsetting Python 2 support
 
-Python 2 support ended in January 2020. Automated `dsub` tests running on
-Python 2 will soon be disabled.
-See [Python's official article](https://www.python.org/doc/sunset-python-2/) for details.
+Python 2 support ended in January 2020.
+See Python's official [Sunsetting Python 2 announcement](https://www.python.org/doc/sunset-python-2/) for details.
+
+Automated `dsub` tests running on Python 2 have been disabled.
+[Release 0.3.10](https://github.com/DataBiosphere/dsub/releases/tag/v0.3.10) is
+the last version of `dsub` that supports Python 2.
 
 Use Python 3.
 

--- a/docs/code.md
+++ b/docs/code.md
@@ -87,7 +87,26 @@ script, see the [Custom Scripts example](../examples/custom_scripts).
 ## --image "Docker image"
 
 The `--image` flag allows you to specify the Docker image to be used for running
-a job. Many software packages are already available in public Docker images at
+your `--command` or `--script`. By default, `dsub` uses a stock Ubuntu image.
+This default image is provided to simplify the getting started experience,
+but may be changed at any time in future releases to ensure newer and more
+secure images.
+
+For reproducible production workflows, be sure to specify an image using
+`--image` flag:
+
+    dsub \
+        ... \
+        --image ubuntu:16.04 \
+        --script hello.sh
+
+You may want to select one of Google's
+[Managed Base Images](https://cloud.google.com/container-registry/docs/managed-base-images).
+
+Note: your `--image` must include the
+[Bash](https://en.wikipedia.org/wiki/Bash_(Unix_shell)) shell interpreter.
+
+Many software packages are already available in public Docker images at
 sites such as [Docker Hub](https://hub.docker.com/). Images can be pulled
 from Docker Hub or any container registry:
 

--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.3.10'
+DSUB_VERSION = '0.3.11.dev0'

--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.3.11.dev0'
+DSUB_VERSION = '0.4.0'

--- a/dsub/commands/ddel.py
+++ b/dsub/commands/ddel.py
@@ -1,4 +1,4 @@
-# Lint as: python2, python3
+# Lint as: python3
 # Copyright 2016 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dsub/commands/dstat.py
+++ b/dsub/commands/dstat.py
@@ -1,4 +1,4 @@
-# Lint as: python2, python3
+# Lint as: python3
 # Copyright 2016 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dsub/commands/dsub.py
+++ b/dsub/commands/dsub.py
@@ -1,4 +1,4 @@
-# Lint as: python2, python3
+# Lint as: python3
 # Copyright 2016 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -1064,6 +1064,7 @@ def _validate_job_and_task_arguments(job_params, task_descriptors):
 
 
 def dsub_main(prog, argv):
+  """Main entry point for dsub."""
   # Parse args and validate
   args = _parse_arguments(prog, argv)
   # intent:

--- a/dsub/commands/dsub.py
+++ b/dsub/commands/dsub.py
@@ -117,6 +117,8 @@ DEFAULT_INPUT_LOCAL_PATH = 'input'
 DEFAULT_OUTPUT_LOCAL_PATH = 'output'
 DEFAULT_MOUNT_LOCAL_PATH = 'mount'
 
+DEFAULT_IMAGE = 'ubuntu:14.04'
+
 
 class TaskParamAction(argparse.Action):
   """Parse the task flag value into a dict."""
@@ -177,7 +179,8 @@ class TaskParamAction(argparse.Action):
 def _check_private_address(args):
   """If --use-private-address is enabled, ensure the Docker path is for GCR."""
   if args.use_private_address:
-    split = args.image.split('/', 1)
+    image = args.image or DEFAULT_IMAGE
+    split = image.split('/', 1)
     if len(split) == 1 or not split[0].endswith('gcr.io'):
       raise ValueError(
           '--use-private-address must specify a --image with a gcr.io host')
@@ -268,10 +271,12 @@ def _parse_arguments(prog, argv):
       metavar='FILE M-N')
   parser.add_argument(
       '--image',
-      default='ubuntu:14.04',
+      # Defaults to None so we can emit a warning if not specified
+      # Will later on be set to DEFAULT_IMAGE
+      default=None,
       help="""Image name from Docker Hub, Google Container Repository, or other
           Docker image service. The task must have READ access to the
-          image. (default: ubuntu:14.04)""")
+          image. (default: {})""".format(DEFAULT_IMAGE))
   parser.add_argument(
       '--dry-run',
       default=False,
@@ -1140,6 +1145,14 @@ def run_main(args):
             'outputs': set()
         }, job_model.Resources())
     ]
+
+  # Emit a warning if default image is used
+  if args.image is None:
+    print('***WARNING: No Docker image specified. The default, '
+          f'`{DEFAULT_IMAGE}` will be used.')
+    print('***WARNING: For reproducible pipelines, specify an image with the '
+          '`--image` flag.')
+    args.image = DEFAULT_IMAGE
 
   return run(
       provider_base.get_provider(args, resources),

--- a/dsub/lib/dsub_errors.py
+++ b/dsub/lib/dsub_errors.py
@@ -1,3 +1,4 @@
+# Lint as: python3
 # Copyright 2017 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dsub/lib/dsub_util.py
+++ b/dsub/lib/dsub_util.py
@@ -1,4 +1,4 @@
-# Lint as: python2, python3
+# Lint as: python3
 # Copyright 2016 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dsub/lib/job_model.py
+++ b/dsub/lib/job_model.py
@@ -1,4 +1,4 @@
-# Lint as: python2, python3
+# Lint as: python3
 # Copyright 2017 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -260,6 +260,7 @@ class LabelParam(collections.namedtuple('LabelParam', ['name', 'value'])):
 
   @staticmethod
   def _check_label_value(value):
+    """Raise ValueError if the label value is invalid."""
     if not value:
       return
 
@@ -334,9 +335,12 @@ class InputFileParam(FileParam):
               disk_size=None,
               disk_type=None):
     validate_param_name(name, 'Input parameter')
-    return super(InputFileParam,
-                 cls).__new__(cls, name, value, docker_path, uri, recursive,
-                              file_provider, disk_size, disk_type)
+    # There is an open bug in the linter for too-many-function-args:
+    # https://github.com/PyCQA/pylint/issues/1789
+    return super(  # pylint: disable=too-many-function-args
+        InputFileParam,
+        cls).__new__(cls, name, value, docker_path, uri, recursive,
+                     file_provider, disk_size, disk_type)
 
 
 class OutputFileParam(FileParam):
@@ -352,9 +356,12 @@ class OutputFileParam(FileParam):
               disk_size=None,
               disk_type=None):
     validate_param_name(name, 'Output parameter')
-    return super(OutputFileParam,
-                 cls).__new__(cls, name, value, docker_path, uri, recursive,
-                              file_provider, disk_size, disk_type)
+    # There is an open bug in the linter for too-many-function-args:
+    # https://github.com/PyCQA/pylint/issues/1789
+    return super(  # pylint: disable=too-many-function-args
+        OutputFileParam,
+        cls).__new__(cls, name, value, docker_path, uri, recursive,
+                     file_provider, disk_size, disk_type)
 
 
 class MountParam(FileParam):
@@ -567,7 +574,7 @@ class TaskDescriptor(object):
   A TaskDescriptor on its own is incomplete and should always be handled in
   the context of a JobDescriptor (described below).
 
-  Args:
+  Attributes:
     task_metadata: Task metadata such as task-id.
     task_params: Task parameters such as labels, envs, inputs, and outputs.
     task_resources: Resources specified such as ram, cpu, and logging path.
@@ -641,7 +648,7 @@ class TaskDescriptor(object):
 class JobDescriptor(object):
   """Metadata, resources, and parameters for a dsub job.
 
-  Args:
+  Attributes:
     job_metadata: Job metadata such as job-id, job-name, and user-id.
     job_params: Job parameters such as labels, envs, inputs, and outputs.
     job_resources: Resources specified such as ram, cpu, and logging path.

--- a/dsub/lib/output_formatter.py
+++ b/dsub/lib/output_formatter.py
@@ -1,4 +1,4 @@
-# Lint as: python2, python3
+# Lint as: python3
 # Copyright 2019 Verily Life Sciences Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dsub/lib/param_util.py
+++ b/dsub/lib/param_util.py
@@ -1,4 +1,4 @@
-# Lint as: python2, python3
+# Lint as: python3
 # Copyright 2016 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dsub/lib/providers_util.py
+++ b/dsub/lib/providers_util.py
@@ -1,3 +1,4 @@
+# Lint as: python3
 # Copyright 2017 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -83,12 +84,14 @@ def build_recursive_localize_env(destination, inputs):
     a multi-line string with a shell script that sets environment variables
     corresponding to the inputs.
   """
+  # pylint: disable=g-complex-comprehension
   export_input_dirs = '\n'.join([
       'export {0}={1}/{2}'.format(var.name, destination.rstrip('/'),
                                   var.docker_path.rstrip('/'))
       for var in inputs
       if var.recursive and var.docker_path
   ])
+  # pylint: enable=g-complex-comprehension
   return export_input_dirs
 
 
@@ -112,7 +115,7 @@ def build_recursive_localize_command(destination, inputs, file_provider):
       var for var in inputs
       if var.recursive and var.file_provider == file_provider
   ]
-
+  # pylint: disable=g-complex-comprehension
   copy_input_dirs = '\n'.join([
       textwrap.dedent("""
       mkdir -p {data_mount}/{docker_path}
@@ -131,6 +134,7 @@ def build_recursive_localize_command(destination, inputs, file_provider):
           data_mount=destination.rstrip('/'),
           docker_path=var.docker_path) for var in filtered_inputs
   ])
+  # pylint: enable=g-complex-comprehension
   return copy_input_dirs
 
 
@@ -150,12 +154,14 @@ def build_recursive_gcs_delocalize_env(source, outputs):
       var for var in outputs
       if var.recursive and var.file_provider == job_model.P_GCS
   ]
+  # pylint: disable=g-complex-comprehension
   return '\n'.join([
       'export {0}={1}/{2}'.format(var.name,
                                   source.rstrip('/'),
                                   var.docker_path.rstrip('/'))
       for var in filtered_outs
   ])
+  # pylint: enable=g-complex-comprehension
 
 
 def build_recursive_delocalize_command(source, outputs, file_provider):
@@ -178,7 +184,7 @@ def build_recursive_delocalize_command(source, outputs, file_provider):
       var for var in outputs
       if var.recursive and var.file_provider == file_provider
   ]
-
+  # pylint: disable=g-complex-comprehension
   return '\n'.join([
       textwrap.dedent("""
       for ((i = 0; i < 3; i++)); do
@@ -195,6 +201,7 @@ def build_recursive_delocalize_command(source, outputs, file_provider):
           docker_path=var.docker_path,
           destination_uri=var.uri) for var in filtered_outputs
   ])
+  # pylint: enable=g-complex-comprehension
 
 
 def get_task_metadata(job_metadata, task_id):

--- a/dsub/lib/resources.py
+++ b/dsub/lib/resources.py
@@ -1,3 +1,4 @@
+# Lint as: python3
 # Copyright 2017 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dsub/lib/retry_util.py
+++ b/dsub/lib/retry_util.py
@@ -1,4 +1,4 @@
-# Lint as: python2, python3
+# Lint as: python3
 # Copyright 2020 Verily Life Sciences Inc. All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dsub/lib/retry_util.py
+++ b/dsub/lib/retry_util.py
@@ -88,6 +88,9 @@ def retry_api_check(exception, verbose):
       _print_retry_error(exception, verbose)
       return True
 
+  if isinstance(exception, socket.timeout):
+    return True
+
   if isinstance(exception, google.auth.exceptions.RefreshError):
     _print_retry_error(exception, verbose)
     return True

--- a/dsub/lib/retry_util.py
+++ b/dsub/lib/retry_util.py
@@ -89,6 +89,7 @@ def retry_api_check(exception, verbose):
       return True
 
   if isinstance(exception, socket.timeout):
+    _print_retry_error(exception, verbose)
     return True
 
   if isinstance(exception, google.auth.exceptions.RefreshError):

--- a/dsub/lib/retry_util.py
+++ b/dsub/lib/retry_util.py
@@ -60,10 +60,25 @@ def _print_retry_error(exception, verbose):
   except AttributeError:
     status_code = ''
 
-  _print_error('{}: Caught exception {} {}'.format(now,
-                                                   type(exception).__name__,
-                                                   status_code))
+  _print_error('{}: Caught exception {} {}'.format(
+      now, get_exception_type_string(exception), status_code))
   _print_error('{}: This request is being retried'.format(now))
+
+
+def get_exception_type_string(exception):
+  """Returns the full path of the exception."""
+  exception_type_string = str(type(exception))
+
+  # This is expected to look something like
+  # "<class 'google.auth.exceptions.RefreshError'>"
+  if exception_type_string.startswith(
+      "<class '") and exception_type_string.endswith("'>"):
+    # Slice off the <class ''> parts
+    return exception_type_string[len("<class '"):-len("'>")]
+  else:
+    # If the exception type looks different than expected,
+    # just print out the whole type.
+    return exception_type_string
 
 
 def retry_api_check(exception, verbose):

--- a/dsub/providers/base.py
+++ b/dsub/providers/base.py
@@ -1,4 +1,4 @@
-# Lint as: python2, python3
+# Lint as: python3
 # Copyright 2017 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dsub/providers/google_base.py
+++ b/dsub/providers/google_base.py
@@ -1,4 +1,4 @@
-# Lint as: python2, python3
+# Lint as: python3
 # Copyright 2018 Verily Life Sciences Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dsub/providers/google_cls_v2.py
+++ b/dsub/providers/google_cls_v2.py
@@ -1,4 +1,4 @@
-# Lint as: python2, python3
+# Lint as: python3
 # Copyright 2019 Verily Life Sciences Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dsub/providers/google_v2.py
+++ b/dsub/providers/google_v2.py
@@ -1,4 +1,4 @@
-# Lint as: python2, python3
+# Lint as: python3
 # Copyright 2019 Verily Life Sciences Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dsub/providers/google_v2_base.py
+++ b/dsub/providers/google_v2_base.py
@@ -1,4 +1,4 @@
-# Lint as: python2, python3
+# Lint as: python3
 # Copyright 2018 Verily Life Sciences Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -670,6 +670,7 @@ class GoogleV2JobProviderBase(base.JobProvider):
 
     persistent_disk_mount_params = param_util.get_persistent_disk_mounts(mounts)
 
+    # pylint: disable=g-complex-comprehension
     persistent_disks = [
         google_v2_pipelines.build_disk(
             name=disk.name.replace('_', '-'),  # Underscores not allowed
@@ -687,6 +688,7 @@ class GoogleV2JobProviderBase(base.JobProvider):
         for persistent_disk, persistent_disk_mount_param in zip(
             persistent_disks, persistent_disk_mount_params)
     ]
+    # pylint: enable=g-complex-comprehension
 
     # The list of "actions" (1-based) will be:
     #   1- continuous copy of log files off to Cloud Storage

--- a/dsub/providers/google_v2_operations.py
+++ b/dsub/providers/google_v2_operations.py
@@ -1,4 +1,4 @@
-# Lint as: python2, python3
+# Lint as: python3
 # Copyright 2018 Verily Life Sciences Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dsub/providers/google_v2_pipelines.py
+++ b/dsub/providers/google_v2_pipelines.py
@@ -1,3 +1,4 @@
+# Lint as: python3
 # Copyright 2018 Verily Life Sciences Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dsub/providers/google_v2_versions.py
+++ b/dsub/providers/google_v2_versions.py
@@ -1,3 +1,4 @@
+# Lint as: python3
 # Copyright 2020 Verily Life Sciences Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dsub/providers/local.py
+++ b/dsub/providers/local.py
@@ -1,4 +1,4 @@
-# Lint as: python2, python3
+# Lint as: python3
 # Copyright 2017 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,7 +54,7 @@ submitted will run concurrently.
 """
 from __future__ import print_function
 
-from collections import namedtuple
+import collections
 import datetime
 import os
 import signal
@@ -897,7 +897,7 @@ class LocalJobProvider(base.JobProvider):
     return script
 
 # The task object for this provider.
-_RawTask = namedtuple('_RawTask', [
+_RawTask = collections.namedtuple('_RawTask', [
     'job_descriptor',
     'task_status',
     'events',

--- a/dsub/providers/provider_base.py
+++ b/dsub/providers/provider_base.py
@@ -1,4 +1,4 @@
-# Lint as: python2, python3
+# Lint as: python3
 # Copyright 2016 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dsub/providers/stub.py
+++ b/dsub/providers/stub.py
@@ -1,4 +1,4 @@
-# Lint as: python2, python3
+# Lint as: python3
 # Copyright 2016 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -96,6 +96,7 @@ class StubJobProvider(base.JobProvider):
       raise NotImplementedError(
           'Lookup by labels and create_time not yet supported by stub.')
 
+    # pylint: disable=g-complex-comprehension
     operations = [
         x for x in self._operations
         if ((not statuses or x.get_field('status', (None, None))[0] in statuses
@@ -106,6 +107,8 @@ class StubJobProvider(base.JobProvider):
             (not task_attempts or
              x.get_field('task-attempt', None) in task_attempts))
     ]
+    # pylint: enable=g-complex-comprehension
+
     if max_tasks > 0:
       operations = operations[:max_tasks]
     return operations
@@ -119,6 +122,7 @@ class StubJobProvider(base.JobProvider):
 
 
 class StubTask(base.Task):
+  """Stub task, for unit testing. Does not actually run anything."""
 
   def __init__(self, op):
     self.op = op

--- a/dsub/providers/test_fails.py
+++ b/dsub/providers/test_fails.py
@@ -1,4 +1,4 @@
-# Lint as: python2, python3
+# Lint as: python3
 # Copyright 2017 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,7 @@ from ..lib import dsub_util
 from ..lib import job_model
 
 
-class FailsException(Exception):
+class FailsError(Exception):
   pass
 
 
@@ -37,7 +37,7 @@ class FailsJobProvider(base.JobProvider):
   def submit_job(self, job_descriptor, skip_if_output_present):
     """Fails if there's anything to submit (so, not skipped)."""
     if not skip_if_output_present:
-      raise FailsException("fails provider made submit_job fail")
+      raise FailsError("fails provider made submit_job fail")
 
     for task_view in job_model.task_view_generator(job_descriptor):
       job_params = task_view.job_params
@@ -49,13 +49,13 @@ class FailsJobProvider(base.JobProvider):
         continue
 
       # if any task is allowed to run, then we fail.
-      raise FailsException("fails provider made submit_job fail")
+      raise FailsError("fails provider made submit_job fail")
 
     return {"job-id": dsub_util.NO_JOB}
 
   def delete_jobs(self, user_ids, job_ids, task_ids, labels, create_time=None):
     del user_ids, job_ids, task_ids, labels, create_time
-    raise FailsException("fails provider made delete_jobs fail")
+    raise FailsError("fails provider made delete_jobs fail")
 
   def lookup_job_tasks(self,
                        statuses,
@@ -67,7 +67,7 @@ class FailsJobProvider(base.JobProvider):
                        create_time=None,
                        max_tasks=0):
     del statuses, user_ids, job_ids, job_names, task_ids, labels, max_tasks
-    raise FailsException("fails provider made lookup_job_tasks fail")
+    raise FailsError("fails provider made lookup_job_tasks fail")
 
   def get_tasks_completion_messages(self, tasks):
     del tasks  # doesn't matter either

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,9 @@ def get_readme_contents():
 setup(
     name='dsub',
 
+    # Python 2 is no longer supported. Use Python 3.
+    python_requires='>=3',
+
     # Versions should comply with PEP440.
     version=get_dsub_version(),
     description=('A command-line tool that makes it easy to submit and run'
@@ -106,7 +109,7 @@ setup(
         #   3 - Alpha
         #   4 - Beta
         #   5 - Production/Stable
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
 
         # Indicate who your project is intended for
         'Intended Audience :: Developers',
@@ -119,8 +122,6 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/test/integration/unit_flags.google-v2.sh
+++ b/test/integration/unit_flags.google-v2.sh
@@ -28,10 +28,13 @@ readonly SCRIPT_DIR="$(dirname "${0}")"
 source "${SCRIPT_DIR}/test_setup_unit.sh"
 
 function call_dsub() {
+  local image="${DOCKER_IMAGE_OVERRIDE:-dummy-image}"
+  
   dsub \
     --provider "${DSUB_PROVIDER}" \
     --project "${PROJECT_ID}" \
     --logging "${LOGGING_OVERRIDE:-${LOGGING}}" \
+    --image "${image}" \
     "${@}" \
     --dry-run \
     1> "${TEST_STDOUT}" \
@@ -384,8 +387,7 @@ readonly -f test_no_accelerator_type_and_count
 function test_network() {
   local subtest="${FUNCNAME[0]}"
 
-  if call_dsub \
-    --image 'marketplace.gcr.io/google/debian9' \
+  if DOCKER_IMAGE_OVERRIDE="marketplace.gcr.io/google/debian9" call_dsub \
     --command 'echo "${TEST_NAME}"' \
     --regions us-central1 \
     --network 'network-name-foo' \

--- a/test/integration/unit_flags.test-fails.sh
+++ b/test/integration/unit_flags.test-fails.sh
@@ -52,5 +52,5 @@ run_dsub \
 # Fancier testing of the label syntax is done in test_param_util.py
 
 assert_err_contains \
-    'FailsException'
+    'FailsError'
 

--- a/test/integration/unit_io.sh
+++ b/test/integration/unit_io.sh
@@ -42,6 +42,7 @@ function call_dsub() {
   run_dsub \
     --script "${SCRIPT}" \
     --env TEST_NAME="${TEST_NAME}" \
+    --image dummy-image \
     ${input:+--input "${input}"} \
     ${output:+--output "${output}"} \
     --dry-run \

--- a/test/integration/unit_tasks.sh
+++ b/test/integration/unit_tasks.sh
@@ -32,6 +32,7 @@ function call_dsub() {
   run_dsub \
     "$@" \
     --command 'echo hello' \
+    --image dummy-image \
     --dry-run \
     1> "${TEST_STDOUT}" \
     2> "${TEST_STDERR}"

--- a/test/unit/retrying_test.py
+++ b/test/unit/retrying_test.py
@@ -25,6 +25,8 @@ import fake_time
 from mock import patch
 import parameterized
 
+import google.auth
+
 
 def chronology():
   # Simulates the passing of time for fake_time.
@@ -177,6 +179,17 @@ class TestRetrying(unittest.TestCase):
       self.assertEqual(mock_api_object.retry_counter, 2)
       self.assertGreaterEqual(elapsed_time_in_seconds(ft), 3)
       self.assertLess(elapsed_time_in_seconds(ft), 3.5)
+
+  @parameterized.parameterized.expand([
+      (apiclient.errors.HttpError(ResponseMock(500, None), b'test_exception'),
+       'googleapiclient.errors.HttpError'),
+      (google.auth.exceptions.RefreshError(),
+       'google.auth.exceptions.RefreshError'),
+      (socket.timeout(), 'socket.timeout'),
+  ])
+  def test_get_exception_type_string(self, exception, expected_type_string):
+    actual_exception_string = retry_util.get_exception_type_string(exception)
+    self.assertEqual(actual_exception_string, expected_type_string)
 
 
 if __name__ == '__main__':

--- a/test/unit/retrying_test.py
+++ b/test/unit/retrying_test.py
@@ -162,6 +162,22 @@ class TestRetrying(unittest.TestCase):
       self.assertGreaterEqual(elapsed_time_in_seconds(ft), 3)
       self.assertLess(elapsed_time_in_seconds(ft), 3.5)
 
+  @parameterized.parameterized.expand([(True,), (False,)])
+  def test_socket_timeout(self, verbose):
+    exception_list = [
+        socket.timeout(),
+        socket.timeout(),
+    ]
+    ft = fake_time.FakeTime(chronology())
+    with patch('time.sleep', new=ft.sleep):
+      api_wrapper_to_test = google_base.Api(verbose)
+      mock_api_object = GoogleApiMock(exception_list)
+      api_wrapper_to_test.execute(mock_api_object)
+      # Expected to retry twice, for a total of 1 + 2 = 3 seconds
+      self.assertEqual(mock_api_object.retry_counter, 2)
+      self.assertGreaterEqual(elapsed_time_in_seconds(ft), 3)
+      self.assertLess(elapsed_time_in_seconds(ft), 3.5)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This release no longer supports Python 2. The last version of dsub that supports Python 2 is 0.3.10.

This release includes:
- dsub
  - Update setup.py in dsub to be Python 3 only.
  - Fix markdown formatting in dsub README
  - Print full path of exceptions that are retried.
  - Print retry errors for socket timeout error.
  - Add socket.timeout exceptions to the retry list.
  - Lint dsub source files as Python3 only. Fix a few lint warnings.
  - Emit warning if default image is used.
