### PR TITLE
PR for 0.4.12 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,16 +471,17 @@ local directory in a similar fashion to support your local development.
 
 ##### Mounting a Google Cloud Storage bucket
 
-To have the `google-v2` or `google-cls-v2` provider mount a Cloud Storage bucket
-using [Cloud Storage FUSE](https://cloud.google.com/storage/docs/gcs-fuse),
-use the `--mount` command line flag:
+To have the `google-v2`, `google-cls-v2`, or `google-batch` provider mount a
+Cloud Storage bucket using
+[Cloud Storage FUSE](https://cloud.google.com/storage/docs/gcs-fuse), use the
+`--mount` command line flag:
 
     --mount RESOURCES=gs://mybucket
 
-The bucket will be mounted into the Docker container running your `--script`
-or `--command` and the location made available via the environment variable
-`${RESOURCES}`. Inside your script, you can reference the mounted path using the
-environment variable. Please read
+The bucket will be mounted read-only into the Docker container running your
+`--script` or `--command` and the location made available via the environment
+variable `${RESOURCES}`. Inside your script, you can reference the mounted path
+using the environment variable. Please read
 [Key differences from a POSIX file system](https://cloud.google.com/storage/docs/gcs-fuse#notes)
 and [Semantics](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/docs/semantics.md)
 before using Cloud Storage FUSE.

--- a/README.md
+++ b/README.md
@@ -247,31 +247,36 @@ implements a consistent runtime environment. The current providers are:
 
 - local
 - google-v2 (the default)
-- google-cls-v2 (*new*)
+- google-cls-v2
+- google-batch (*new*)
 
 More details on the runtime environment implemented by the backend providers
 can be found in [dsub backend providers](https://github.com/DataBiosphere/dsub/blob/main/docs/providers/README.md).
 
-### Differences between `google-v2` and `google-cls-v2`
+### Differences between `google-v2`, `google-cls-v2` and `google-batch`
 
 The `google-cls-v2` provider is built on the Cloud Life Sciences `v2beta` API.
 This API is very similar to its predecessor, the Genomics `v2alpha1` API.
 Details of the differences can be found in the
 [Migration Guide](https://cloud.google.com/life-sciences/docs/how-tos/migration).
 
-`dsub` largely hides the differences between the two APIs, but there are a
+The `google-batch` provider is built on the Cloud Batch API.
+Details of Cloud Life Sciences versus Batch can be found in this
+[Migration Guide](https://cloud.google.com/batch/docs/migrate-to-batch-from-cloud-life-sciences).
+
+`dsub` largely hides the differences between the APIs, but there are a
 few difference to note:
 
-- `v2beta` is a regional service, `v2alpha1` is a global service
+- `v2beta` and Cloud Batch are regional services, `v2alpha1` is a global service
 
 What this means is that with `v2alpha1`, the metadata about your tasks
-(called "operations"), is stored in a global database, while with `v2beta`, the
-metadata about your tasks are stored in a regional database. If your operation
-information needs to stay in a particular region, use the `v2beta` API
-(the `google-cls-v2` provider), and specify the `--location` where your
-operation information should be stored.
+(called "operations"), is stored in a global database, while with `v2beta` and
+Cloud Batch, the metadata about your tasks are stored in a regional database. If
+your operation/job information needs to stay in a particular region, use the
+`v2beta` or Batch API (the `google-cls-v2` or `google-batch` provider), and
+specify the `--location` where your operation/job information should be stored.
 
-- The `--regions` and `--zones` flags can be omitted when using `google-cls-v2`
+- The `--regions` and `--zones` flags can be omitted when using `google-cls-v2` and `google-batch`
 
 The `--regions` and `--zones` flags for `dsub` specify where the tasks should
 run. More specifically, this specifies what Compute Engine Zones to use for
@@ -280,9 +285,9 @@ the VMs that run your tasks.
 With the `google-v2` provider, there is no default region or zone, and thus
 one of the `--regions` or `--zones` flags is required.
 
-With `google-cls-v2`, the `--location` flag defaults to `us-central1`, and
-if the `--regions` and `--zones` flags are omitted, the `location` will be
-used as the default `regions` list.
+With `google-cls-v2` and `google-batch`, the `--location` flag defaults to
+`us-central1`, and if the `--regions` and `--zones` flags are omitted, the
+`location` will be used as the default `regions` list.
 
 ## `dsub` features
 

--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.4.12.dev0'
+DSUB_VERSION = '0.4.12'

--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -26,4 +26,4 @@ A typical release sequence will be versioned as:
   0.1.3.dev0 -> 0.1.3 -> 0.1.4.dev0 -> ...
 """
 
-DSUB_VERSION = '0.4.11'
+DSUB_VERSION = '0.4.12.dev0'

--- a/dsub/providers/batch_dummy.py
+++ b/dsub/providers/batch_dummy.py
@@ -39,6 +39,7 @@ class types(object):
     Disk = None
     NetworkPolicy = None
     Accelerator = None
+    LocationPolicy = None
 
   class LogsPolicy(object):
     Destination = None

--- a/dsub/providers/google_batch_operations.py
+++ b/dsub/providers/google_batch_operations.py
@@ -262,12 +262,13 @@ def build_allocation_policy(
     ipts: List[batch_v1.types.AllocationPolicy.InstancePolicyOrTemplate],
     service_account: batch_v1.types.ServiceAccount,
     network_policy: batch_v1.types.AllocationPolicy.NetworkPolicy,
+    location_policy: batch_v1.types.AllocationPolicy.LocationPolicy,
 ) -> batch_v1.types.AllocationPolicy:
   allocation_policy = batch_v1.AllocationPolicy()
   allocation_policy.instances = ipts
   allocation_policy.service_account = service_account
   allocation_policy.network = network_policy
-
+  allocation_policy.location = location_policy
   return allocation_policy
 
 
@@ -346,3 +347,11 @@ def build_accelerators(
     accelerators.append(accelerator)
 
   return accelerators
+
+
+def build_location_policy(
+    allowed_locations: List[str],
+) -> batch_v1.types.AllocationPolicy.LocationPolicy:
+  location_policy = batch_v1.AllocationPolicy.LocationPolicy()
+  location_policy.allowed_locations = allowed_locations
+  return location_policy

--- a/dsub/providers/google_batch_operations.py
+++ b/dsub/providers/google_batch_operations.py
@@ -220,6 +220,26 @@ def build_volume(disk: str, path: str) -> batch_v1.types.Volume:
   return volume
 
 
+def build_gcs_volume(
+    bucket: str, path: str, mount_options: List[str]
+) -> batch_v1.types.Volume:
+  """Build a Volume object mounted to a GCS bucket for a Batch request.
+
+  Args:
+    bucket (str): Name of bucket to mount (without the gs:// prefix)
+    path (str): Path to mount the bucket at inside the container.
+    mount_options (List[str]): List of mount options
+
+  Returns:
+    An object representing a Mount.
+  """
+  volume = batch_v1.Volume()
+  volume.gcs = batch_v1.GCS(remote_path=bucket)
+  volume.mount_path = path
+  volume.mount_options = mount_options
+  return volume
+
+
 def build_network_policy(
     network: str,
     subnetwork: str,

--- a/test/integration/test_setup.sh
+++ b/test/integration/test_setup.sh
@@ -34,7 +34,8 @@
 #   If the script name is <test>.<provider>.sh, pull out the provider.
 #   If the script name is <test>.sh, use "local".
 # If the DSUB_PROVIDER is set, make sure it is correct for a provider test.
-#   Special-case the google-v2 tests to be runnable for google-cls-v2.
+#   Special-case the google-v2 tests to be runnable for google-cls-v2
+#   and google-batch.
 
 readonly SCRIPT_NAME="$(basename "$0")"
 readonly SCRIPT_DEFAULT_PROVIDER=$(
@@ -48,6 +49,9 @@ elif [[ -n "${SCRIPT_DEFAULT_PROVIDER}" ]]; then
   if [[ "${DSUB_PROVIDER}" == "google-cls-v2" ]] && \
      [[ "${SCRIPT_DEFAULT_PROVIDER}" == "google-v2" ]]; then
      echo "Running google-v2 e2e/unit tests with provider google-cls-v2"
+  elif [[ "${DSUB_PROVIDER}" == "google-batch" ]] && \
+     [[ "${SCRIPT_DEFAULT_PROVIDER}" == "google-v2" ]]; then
+     echo "Running google-v2 e2e/unit tests with provider google-batch"
   elif [[ "${DSUB_PROVIDER}" != "${SCRIPT_DEFAULT_PROVIDER}" ]]; then
     1>&2 echo "DSUB_PROVIDER is '${DSUB_PROVIDER:-}' not '${SCRIPT_DEFAULT_PROVIDER}'"
     exit 1

--- a/test/integration/unit_flags.google-batch.sh
+++ b/test/integration/unit_flags.google-batch.sh
@@ -258,7 +258,124 @@ function test_network() {
 }
 readonly -f test_network
 
-# Run the tests
+function test_location() {
+  local subtest="${FUNCNAME[0]}"
+
+  if call_dsub \
+    --location us-west2 \
+    --command 'echo "${TEST_NAME}"'; then
+
+    # Check that the output contains expected values
+    location_result=$(grep " allowed_locations:" "${TEST_STDERR}" | awk -F\" '{print $2}')
+    if [[ "${location_result}" != "regions/us-west2" ]]; then
+        1>&2 echo "location was actually ${location_result}, expected regions/us-west2"
+        exit 1
+    fi
+
+    test_passed "${subtest}"
+  else
+    1>&2 echo "Using the location flag generated an error"
+
+    test_failed "${subtest}"
+  fi
+}
+readonly -f test_location
+
+function test_neither_region_nor_zone() {
+  local subtest="${FUNCNAME[0]}"
+
+  if call_dsub \
+    --command 'echo "${TEST_NAME}"'; then
+
+    # Check that the output contains expected values
+    location_result=$(grep " allowed_locations:" "${TEST_STDERR}" | awk -F\" '{print $2}')
+    if [[ "${location_result}" != "regions/us-central1" ]]; then
+        1>&2 echo "location was actually ${location_result}, expected regions/us-central1"
+        exit 1
+    fi
+
+    test_passed "${subtest}"
+  else
+    1>&2 echo "Location not used as default region"
+
+    test_failed "${subtest}"
+  fi
+}
+readonly -f test_neither_region_nor_zone
+
+function test_region_and_zone() {
+  local subtest="${FUNCNAME[0]}"
+
+  if call_dsub \
+    --command 'echo "${TEST_NAME}"' \
+    --zones us-central1-f \
+    --regions us-central1; then
+
+    # Check that the output contains expected values
+    regions_result=$(grep " allowed_locations: \"regions/" "${TEST_STDERR}" | awk -F\" '{print $2}')
+    if [[ "${regions_result}" != "regions/us-central1" ]]; then
+        1>&2 echo "location was actually ${regions_result}, expected regions/us-central1"
+        exit 1
+    fi
+
+    zones_result=$(grep " allowed_locations: \"zones/" "${TEST_STDERR}" | awk -F\" '{print $2}')
+    if [[ "${zones_result}" != "zones/us-central1-f" ]]; then
+        1>&2 echo "location was actually ${zones_result}, expected zones/us-central1-f"
+        exit 1
+    fi
+
+    test_passed "${subtest}"
+  else
+    1>&2 echo "Location not used as default region"
+
+    test_failed "${subtest}"
+  fi
+}
+readonly -f test_neither_region_nor_zone
+
+function test_regions() {
+  local subtest="${FUNCNAME[0]}"
+
+  if call_dsub \
+    --command 'echo "${TEST_NAME}"' \
+    --regions us-central1; then
+
+    # Check that the output contains expected values
+    location_result=$(grep " allowed_locations:" "${TEST_STDERR}" | awk -F\" '{print $2}')
+    if [[ "${location_result}" != "regions/us-central1" ]]; then
+        1>&2 echo "location was actually ${location_result}, expected regions/us-central1"
+        exit 1
+    fi
+
+    test_passed "${subtest}"
+  else
+    test_failed "${subtest}"
+  fi
+}
+readonly -f test_regions
+
+function test_zones() {
+  local subtest="${FUNCNAME[0]}"
+
+  if call_dsub \
+    --command 'echo "${TEST_NAME}"' \
+    --zones us-central1-a; then
+
+    # Check that the output contains expected values
+    location_result=$(grep " allowed_locations:" "${TEST_STDERR}" | awk -F\" '{print $2}')
+    if [[ "${location_result}" != "zones/us-central1-a" ]]; then
+        1>&2 echo "location was actually ${location_result}, expected zones/us-central1-a"
+        exit 1
+    fi
+
+    test_passed "${subtest}"
+  else
+    test_failed "${subtest}"
+  fi
+}
+readonly -f test_zones
+
+# # Run the tests
 trap "exit_handler" EXIT
 
 mkdir -p "${TEST_TMP}"
@@ -284,3 +401,10 @@ test_no_service_account
 
 echo
 test_network
+
+echo
+test_location
+test_neither_region_nor_zone
+test_region_and_zone
+test_regions
+test_zones

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -231,6 +231,7 @@ function get_test_providers() {
     e2e_input_wildcards.sh | \
     e2e_io.sh | \
     e2e_io_auto.sh | \
+    e2e_io_gcs_tasks.sh | \
     e2e_io_recursive.sh | \
     e2e_io_tasks.sh | \
     e2e_logging_content.sh | \

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -243,6 +243,9 @@ function get_test_providers() {
     e2e_non_root.sh | \
     e2e_python.sh | \
     e2e_requester_pays_buckets.sh | \
+    e2e_retries_success.sh | \
+    e2e_retries_fail_1.sh | \
+    e2e_retries_fail_2.sh | \
     e2e_runtime.sh)
       local all_provider_list="${DSUB_PROVIDER:-local google-v2 google-cls-v2 google-batch}"
       ;;

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -226,11 +226,13 @@ function get_test_providers() {
     e2e_command_flag.sh | \
     e2e_dsub_summary.sh | \
     e2e_env_list.py | \
+    e2e_env_tasks.sh | \
     e2e_image.sh | \
     e2e_input_wildcards.sh | \
     e2e_io.sh | \
     e2e_io_auto.sh | \
     e2e_io_recursive.sh | \
+    e2e_io_tasks.sh | \
     e2e_logging_content.sh | \
     e2e_logging_fail.sh | \
     e2e_logging_paths.sh | \

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -229,6 +229,7 @@ function get_test_providers() {
     e2e_image.sh | \
     e2e_input_wildcards.sh | \
     e2e_io.sh | \
+    e2e_io_auto.sh | \
     e2e_io_recursive.sh | \
     e2e_logging_content.sh | \
     e2e_logging_fail.sh | \

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -232,6 +232,7 @@ function get_test_providers() {
     e2e_io.sh | \
     e2e_io_auto.sh | \
     e2e_io_gcs_tasks.sh | \
+    e2e_io_mount_bucket.google-v2.sh | \
     e2e_io_recursive.sh | \
     e2e_io_tasks.sh | \
     e2e_logging_content.sh | \


### PR DESCRIPTION
This release includes:
- `google-batch` provider updates:
  - Set environments per runnable. Submit 1 Batch job per `dsub` task.
  - Fix Batch job_ids for `dsub` tasks and retries
  - Sort `dstat` tasks by create-time
  - Enable `e2e_io_gcs_tasks.sh`
  - Add support for `--location`, `--regions`, and `--zones`
  - Support gcsfuse mounting buckets with the --mount parameter