### PR TITLE
Fixed problem with --min-ram when using google-batch provider

### DIFF
--- a/dsub/providers/batch_dummy.py
+++ b/dsub/providers/batch_dummy.py
@@ -26,6 +26,7 @@ class types(object):
   TaskSpec = None
   Environment = None
   ServiceAccount = None
+  ComputeResource = None
 
   class task(object):
 

--- a/dsub/providers/google_batch.py
+++ b/dsub/providers/google_batch.py
@@ -797,10 +797,11 @@ class GoogleBatchJobProvider(google_utils.GoogleJobProviderBase):
         batch_v1.LogsPolicy.Destination.PATH,
         _BATCH_LOG_DIR + '/',
     )
-
+    compute_resource = google_batch_operations.build_compute_resource(cpu_milli=(job_resources.min_cores  * 1000 if job_resources.min_cores else None), 
+                                                                      memory_mib = (job_resources.min_ram * 1024) if job_resources.min_ram else None)
     # Bring together the task definition(s) and build the Job request.
     task_spec = google_batch_operations.build_task_spec(
-        runnables=runnables, volumes=([datadisk_volume] + gcs_volumes)
+        runnables=runnables, volumes=([datadisk_volume] + gcs_volumes), compute_resource=compute_resource
     )
     task_group = google_batch_operations.build_task_group(
         task_spec, task_count=1, task_count_per_node=1

--- a/dsub/providers/google_batch_operations.py
+++ b/dsub/providers/google_batch_operations.py
@@ -126,12 +126,14 @@ def build_job(
 def build_task_spec(
     runnables: List[batch_v1.types.task.Runnable],
     volumes: List[batch_v1.types.Volume],
+    compute_resource: batch_v1.types.ComputeResource
 ) -> batch_v1.types.TaskSpec:
   """Build a TaskSpec object for a Batch request.
 
   Args:
       runnables (List[Runnable]): List of Runnable objects
       volumes (List[Volume]): List of Volume objects
+      compute_resource: The compute resource object
 
   Returns:
       A TaskSpec object.
@@ -139,6 +141,7 @@ def build_task_spec(
   task_spec = batch_v1.TaskSpec()
   task_spec.runnables = runnables
   task_spec.volumes = volumes
+  task_spec.compute_resource = compute_resource
   return task_spec
 
 
@@ -321,6 +324,24 @@ def build_logs_policy(
 
   return logs_policy
 
+def build_compute_resource(
+    cpu_milli: int,
+    memory_mib: int
+) -> batch_v1.types.ComputeResource:
+  """Build an compute resource for a Batch request.
+
+  Args:
+    cpu_milli (int): the amount of CPU resources per task in milliCPU units.
+    memory_mib (int): the amount of memory per task in MiB units.
+    
+  Returns:
+    An object representing an compute resource.
+  """
+  compute_resource = batch_v1.ComputeResource()
+  compute_resource.cpu_milli = cpu_milli
+  compute_resource.memory_mib = memory_mib
+  compute_resource.boot_disk_mib = 0
+  return compute_resource
 
 def build_instance_policy(
     boot_disk: batch_v1.types.AllocationPolicy.Disk,


### PR DESCRIPTION
I tried switching from using pipeline API to the google-batch provider for a batch job that we've run regularly for years. However, when submitting it as a job to the batch API, the job consistently was getting killed, apparently by the OOM killer.

The job was submitted with `--min-ram 10` and when looking at the cloud console, I can see it allocated an appropriate machine type, but the memory reported is 1.95.

![image](https://github.com/user-attachments/assets/86db2eb8-1c15-4aeb-b139-11197e530d60)
 
 Looking at the code I noticed that compute_resources was not being set, and according to the [batch api docs](https://cloud.google.com/batch/docs/reference/rest/v1alpha/projects.locations.jobs#ComputeResource) there are per-task resource memory and cpu caps which default to 2GB and 2 cpus if not specified otherwise.
 
 This PR adds a change which uses the values from `job_resources` to populate the `compute_resource` field on the job submission.

It seems to work for me, and I thought it'd be useful to merge it into the mainline for anyone else that might encounter this. (Especially as the pipeline API is being shutdown and the Batch API is what google recommends migrating to)

Please let me know if there are additional changes that you would like in order to get this merged in.