### PR TITLE
Fix for --format provider-json

### DIFF
--- a/dsub/commands/dstat.py
+++ b/dsub/commands/dstat.py
@@ -201,6 +201,7 @@ def main():
   # to provide a username automatically.
   user_ids = set(args.users) if args.users else {dsub_util.get_os_user()}
   labels = param_util.parse_pair_args(args.label, job_model.LabelParam)
+  raw_format = bool(args.format == 'provider-json')
 
   job_producer = dstat_job_producer(
       provider=provider,
@@ -216,12 +217,15 @@ def main():
       full_output=args.full,
       summary_output=args.summary,
       poll_interval=poll_interval,
-      raw_format=bool(args.format == 'provider-json'))
+      raw_format=raw_format)
 
   # Track if any jobs are running in the event --wait was requested.
   for poll_event_tasks in job_producer:
     rows = poll_event_tasks
-    formatter.prepare_and_print_table(rows, args.summary)
+    if raw_format:
+        formatter.print_table(rows)
+    else:
+      formatter.prepare_and_print_table(rows, args.summary)
 
 
 def dstat_job_producer(provider,

--- a/dsub/providers/google_batch.py
+++ b/dsub/providers/google_batch.py
@@ -32,6 +32,7 @@ from . import google_base
 from . import google_batch_operations
 from . import google_custom_machine
 from . import google_utils
+from proto import message
 
 # pylint: disable=g-import-not-at-top
 try:
@@ -207,7 +208,7 @@ class GoogleBatchOperation(base.Task):
     self._job_descriptor = self._try_op_to_job_descriptor()
 
   def raw_task_data(self):
-    return self._op
+    return message.Message.to_dict(self._op)
 
   def _try_op_to_job_descriptor(self):
     # The _META_YAML_REPR field in the 'prepare' action enables reconstructing


### PR DESCRIPTION
A fix for a very minor issue where running `dsub ... --format provider-json` was resulting in the following exception:

```
Traceback (most recent call last):
  File "/opt/homebrew/Caskroom/miniconda/base/envs/dsub/bin/dstat", line 33, in <module>
    sys.exit(load_entry_point('dsub', 'console_scripts', 'dstat')())
  File "/Users/pmontgom/dev/dsub/dsub/commands/dstat.py", line 224, in main
    formatter.prepare_and_print_table(rows, args.summary)
  File "/Users/pmontgom/dev/dsub/dsub/lib/output_formatter.py", line 80, in prepare_and_print_table
    row = self.prepare_output(row)
  File "/Users/pmontgom/dev/dsub/dsub/lib/output_formatter.py", line 60, in prepare_output
    if col in row:
  File "/opt/homebrew/Caskroom/miniconda/base/envs/dsub/lib/python3.10/site-packages/proto/message.py", line 688, in __contains__
    pb_value = getattr(self._pb, key)
AttributeError: last-update
```

Tried to create a fix, which not particularly elegant, makes minimal changes.

Happy to take feedback if you think it'd be better fixed a different way.

Thanks.