### PR TITLE
Fix/version0.5.5

### DIFF
--- a/dsub/providers/google_utils.py
+++ b/dsub/providers/google_utils.py
@@ -70,7 +70,7 @@ def make_runtime_dirs_command(script_dir: str, tmp_dir: str,
 
 # Action steps that interact with GCS need gcloud and Python.
 # Use the 'slim' variant of the cloud-sdk image as it is much smaller.
-CLOUD_SDK_IMAGE = 'gcr.io/google.com/cloudsdktool/cloud-sdk:499.0.0-slim'
+CLOUD_SDK_IMAGE = 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
 
 # Name of the data disk
 DATA_DISK_NAME = 'datadisk'

--- a/dsub/providers/google_utils.py
+++ b/dsub/providers/google_utils.py
@@ -70,6 +70,11 @@ def make_runtime_dirs_command(script_dir: str, tmp_dir: str,
 
 # Action steps that interact with GCS need gcloud and Python.
 # Use the 'slim' variant of the cloud-sdk image as it is much smaller.
+# Use the rolling tag rather than a pinned version: gcr.io enforces a 1-year
+# retention policy that deletes older numbered tags, which breaks every dsub
+# release that pins one. See
+# https://github.com/GoogleCloudPlatform/cloud-sdk-docker#package-retention-policy
+# and https://github.com/DataBiosphere/dsub/issues/336.
 CLOUD_SDK_IMAGE = 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
 
 # Name of the data disk

--- a/test/integration/e2e_block_external_network.google-cls-v2.sh
+++ b/test/integration/e2e_block_external_network.google-cls-v2.sh
@@ -35,7 +35,7 @@ set +o errexit
 # running "gcloud storage ls" below. Otherwise, gcloud storage will retry
 # due to the network error.
 JOB_ID="$(run_dsub \
-  --image 'gcr.io/google.com/cloudsdktool/cloud-sdk:499.0.0-slim' \
+  --image 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim' \
   --block-external-network \
   --script "${SCRIPT_DIR}/script_block_external_network.sh" \
   --retries 1 \


### PR DESCRIPTION
As per https://github.com/DataBiosphere/dsub/pull/337 from shawnfan19:fix/cloud-sdk-image-retention: gcr.io now enforces a documented 1-year retention policy on the cloud-sdk image repo ([policy](https://github.com/GoogleCloudPlatform/cloud-sdk-docker#package-retention-policy)). On ~2026-09-01 it deleted every numbered tag older than 537.0.0 (2025-09) — including 499.0.0-slim pinned on main/v0.5.3/v0.5.4 and 294.0.0-slim pinned by ≤ v0.5.2. Since dsub runs all auxiliary runnables on this image, every job on the Google providers now fails ~40 s after RUNNING with exit code 1 and produces no logs (the always_run final-logging runnable cannot pull the image either). Full diagnosis and registry-level repro in https://github.com/DataBiosphere/dsub/issues/336.

This is the minimal fix: point CLOUD_SDK_IMAGE at the rolling :slim tag, which the retention policy retains, and document the policy at the definition. If maintainers prefer a pinned tag, any numbered tag ≥ 537.0.0 currently resolves (e.g. 539.0.0-slim) — with the caveat that the policy will delete it within a year, re-breaking all releases that pin it. Making CLOUD_SDK_IMAGE operator-overridable (env var) would allow self-service next time.

Verified end-to-end on Google Batch (All of Us Researcher Workbench, 2026-09-01): current :slim provides everything the runnable scripts need (bash, python3, gsutil, gcloud), and with a live tag jobs complete with logs delivered. (Installs of ≤ 0.5.2 additionally need the bare-python → python3 fix that main already has; hotfix in https://github.com/DataBiosphere/dsub/issues/336.)

Fixes https://github.com/DataBiosphere/dsub/issues/336 from shawnfan19:fix/cloud-sdk-image-retention as per https://github.com/DataBiosphere/dsub/pull/337