### PR TITLE
PR for 0.5.5 release bump CLOUD_SDK_IMAGE to a live tag (gcr.io retention deleted 499.0.0-slim)

### DIFF
--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -27,5 +27,5 @@ A typical release sequence will be versioned as:
 """
 
 
-DSUB_VERSION = '0.5.5.dev0'
+DSUB_VERSION = '0.5.5'
 

--- a/dsub/_dsub_version.py
+++ b/dsub/_dsub_version.py
@@ -27,5 +27,5 @@ A typical release sequence will be versioned as:
 """
 
 
-DSUB_VERSION = '0.5.4'
+DSUB_VERSION = '0.5.5.dev0'
 

--- a/dsub/providers/google_utils.py
+++ b/dsub/providers/google_utils.py
@@ -70,12 +70,25 @@ def make_runtime_dirs_command(script_dir: str, tmp_dir: str,
 
 # Action steps that interact with GCS need gcloud and Python.
 # Use the 'slim' variant of the cloud-sdk image as it is much smaller.
-# Use the rolling tag rather than a pinned version: gcr.io enforces a 1-year
-# retention policy that deletes older numbered tags, which breaks every dsub
-# release that pins one. See
+#
+# The default is the rolling 'slim' tag rather than a pinned version. This is a
+# deliberate exception to the version-pinning policy described in setup.py:
+# gcr.io enforces a 1-year retention policy that deletes older numbered tags,
+# so pinning guarantees that every released version of dsub breaks on a
+# schedule. See
 # https://github.com/GoogleCloudPlatform/cloud-sdk-docker#package-retention-policy
 # and https://github.com/DataBiosphere/dsub/issues/336.
-CLOUD_SDK_IMAGE = 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+#
+# The tradeoff is that the auxiliary runnables now follow whatever the cloud-sdk
+# image ships, including python3 (used to decode the user script) and the
+# "gcloud storage" flag surface (used to localize and delocalize files).
+# DSUB_CLOUD_SDK_IMAGE lets an operator pin a known-good image immediately if a
+# cloud-sdk release regresses them, rather than waiting on a dsub release:
+#
+#   export DSUB_CLOUD_SDK_IMAGE=gcr.io/google.com/cloudsdktool/cloud-sdk:537.0.0-slim
+DEFAULT_CLOUD_SDK_IMAGE = 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+CLOUD_SDK_IMAGE = (
+    os.environ.get('DSUB_CLOUD_SDK_IMAGE') or DEFAULT_CLOUD_SDK_IMAGE)
 
 # Name of the data disk
 DATA_DISK_NAME = 'datadisk'

--- a/dsub/providers/google_utils.py
+++ b/dsub/providers/google_utils.py
@@ -70,7 +70,7 @@ def make_runtime_dirs_command(script_dir: str, tmp_dir: str,
 
 # Action steps that interact with GCS need gcloud and Python.
 # Use the 'slim' variant of the cloud-sdk image as it is much smaller.
-CLOUD_SDK_IMAGE = 'gcr.io/google.com/cloudsdktool/cloud-sdk:499.0.0-slim'
+CLOUD_SDK_IMAGE = 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
 
 # Name of the data disk
 DATA_DISK_NAME = 'datadisk'

--- a/dsub/providers/google_utils.py
+++ b/dsub/providers/google_utils.py
@@ -70,6 +70,11 @@ def make_runtime_dirs_command(script_dir: str, tmp_dir: str,
 
 # Action steps that interact with GCS need gcloud and Python.
 # Use the 'slim' variant of the cloud-sdk image as it is much smaller.
+# Use the rolling tag rather than a pinned version: gcr.io enforces a 1-year
+# retention policy that deletes older numbered tags, which breaks every dsub
+# release that pins one. See
+# https://github.com/GoogleCloudPlatform/cloud-sdk-docker#package-retention-policy
+# and https://github.com/DataBiosphere/dsub/issues/336.
 CLOUD_SDK_IMAGE = 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
 
 # Name of the data disk

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,13 @@ from setuptools import find_packages
 from setuptools import setup
 
 
+# Note that this pinning policy covers the Python libraries dsub itself runs
+# with; it deliberately does not extend to the cloud-sdk container image the
+# Google providers run their auxiliary steps in. Pinning that image is actively
+# harmful, because gcr.io deletes numbered tags after a year and every release
+# pinning one then breaks. See CLOUD_SDK_IMAGE in dsub/providers/google_utils.py
+# for that tradeoff and for DSUB_CLOUD_SDK_IMAGE, which lets an operator pin the
+# image locally when a cloud-sdk release regresses them.
 _DEPENDENCIES = [
     # dependencies for dsub, ddel, dstat
     # Pin to known working versions to prevent episodic breakage from library

--- a/test/integration/e2e_block_external_network.google-cls-v2.sh
+++ b/test/integration/e2e_block_external_network.google-cls-v2.sh
@@ -27,6 +27,18 @@ readonly SCRIPT_DIR="$(dirname "${0}")"
 # Do standard test setup
 source "${SCRIPT_DIR}/test_setup_e2e.sh"
 
+# The user script runs "gcloud storage ls", so it needs an image with gcloud.
+# Read dsub's own constant rather than duplicating the image reference here;
+# that keeps this test from going stale when the constant is updated, and lets
+# DSUB_CLOUD_SDK_IMAGE steer the test too.
+readonly CLOUD_SDK_IMAGE="$(python3 -c \
+  'from dsub.providers import google_utils; print(google_utils.CLOUD_SDK_IMAGE)')"
+if [[ -z "${CLOUD_SDK_IMAGE}" ]]; then
+  1>&2 echo "Could not read CLOUD_SDK_IMAGE from dsub.providers.google_utils."
+  exit 1
+fi
+echo "Using image: ${CLOUD_SDK_IMAGE}"
+
 echo "Launching pipeline..."
 
 set +o errexit
@@ -35,7 +47,7 @@ set +o errexit
 # running "gcloud storage ls" below. Otherwise, gcloud storage will retry
 # due to the network error.
 JOB_ID="$(run_dsub \
-  --image 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim' \
+  --image "${CLOUD_SDK_IMAGE}" \
   --block-external-network \
   --script "${SCRIPT_DIR}/script_block_external_network.sh" \
   --retries 1 \
@@ -53,16 +65,28 @@ echo "Checking stderr of both attempts..."
 readonly ATTEMPT_1_STDERR_LOG="$(dirname "${LOGGING}")/${TEST_NAME}.1-stderr.log"
 readonly ATTEMPT_2_STDERR_LOG="$(dirname "${LOGGING}")/${TEST_NAME}.2-stderr.log"
 
+# A blocked network reaches the log as one of several messages depending on the
+# gcloud version in the image: older releases report a handled urllib3 "Max
+# retries exceeded", while current ones surface an unhandled "gcloud crashed
+# (ConnectionError)" traceback. Assert on the invariant -- gcloud could not
+# reach the GCS endpoint -- rather than on one release's prose, so that a
+# reworded gcloud error does not read as a dsub regression.
+readonly GCLOUD_NETWORK_ERROR_RE='max retries exceeded|connectionerror|connection refused|failed to establish a new connection|could not resolve|name or service not known|network is unreachable'
+# curl reports its failure on a single line, so keep the host in the pattern.
+# Otherwise a gcloud network error elsewhere in the log could satisfy this
+# check while curl's own error is missing.
+readonly CURL_NETWORK_ERROR_RE='(could not resolve host|failed to connect to|resolving timed out.*) *:? *google\.com'
+
 for STDERR_LOG_FILE in "${ATTEMPT_1_STDERR_LOG}" "${ATTEMPT_2_STDERR_LOG}" ; do
   RESULT="$(gcloud storage cat "${STDERR_LOG_FILE}")"
   if ! echo "${RESULT}" | grep -qi "storage.googleapis.com" \
-      || ! echo "${RESULT}" | grep -qi "Max retries exceeded"; then
+      || ! echo "${RESULT}" | grep -qiE "${GCLOUD_NETWORK_ERROR_RE}"; then
     1>&2 echo "Network error from gcloud not found in the dsub stderr log!"
     1>&2 echo "${RESULT}"
     exit 1
   fi
 
-  if ! echo "${RESULT}" | grep -qi "Could not resolve host: google.com"; then
+  if ! echo "${RESULT}" | grep -qiE "${CURL_NETWORK_ERROR_RE}"; then
     1>&2 echo "Network error from curl not found in the dsub stderr log!"
     1>&2 echo "${RESULT}"
     exit 1

--- a/test/integration/e2e_block_external_network.google-cls-v2.sh
+++ b/test/integration/e2e_block_external_network.google-cls-v2.sh
@@ -35,7 +35,7 @@ set +o errexit
 # running "gcloud storage ls" below. Otherwise, gcloud storage will retry
 # due to the network error.
 JOB_ID="$(run_dsub \
-  --image 'gcr.io/google.com/cloudsdktool/cloud-sdk:499.0.0-slim' \
+  --image 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim' \
   --block-external-network \
   --script "${SCRIPT_DIR}/script_block_external_network.sh" \
   --retries 1 \

--- a/test/unit/cloud_sdk_image_test.py
+++ b/test/unit/cloud_sdk_image_test.py
@@ -1,0 +1,245 @@
+# Copyright 2026 Verily Life Sciences Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the cloud-sdk image used by the Google providers.
+
+The google-batch and google-cls-v2 providers run their localization,
+delocalization, and logging steps in CLOUD_SDK_IMAGE. If that image is not
+pullable, every job fails at runtime while the rest of the test suite stays
+green, because no other test references the constant.
+
+That is not hypothetical: gcr.io deletes numbered cloud-sdk tags after a year,
+which broke every dsub release that pinned one
+(https://github.com/DataBiosphere/dsub/issues/336).
+
+This test resolves the image's manifest against the registry over the Docker
+Registry HTTP API V2 and fails if it does not exist. It needs no credentials,
+no Docker daemon, and no gcloud. Because the tag is parsed out of the constant
+itself, the test follows any future edit to it, and so covers re-pinning to a
+numbered tag, renaming the repository (cloud-sdk -> google-cloud-cli), and
+retention deletions alike.
+
+Set DSUB_SKIP_NETWORK_TESTS=1 to skip. The test also skips, rather than fails,
+when the registry cannot be reached at all, or when it refuses to serve an
+anonymous read, so that an offline run or a privately hosted image does not
+report a false breakage. A registry that answers but reports the image missing
+is always a failure.
+"""
+
+import importlib
+import json
+import os
+import re
+import unittest
+from unittest import mock
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from dsub.providers import google_utils
+
+# Ask for every manifest media type the cloud-sdk image might be published as.
+# A multi-architecture image answers with an index rather than a manifest, and a
+# registry may return 404 for a media type it was not asked about.
+_ACCEPT_MANIFEST_TYPES = ', '.join([
+    'application/vnd.docker.distribution.manifest.list.v2+json',
+    'application/vnd.docker.distribution.manifest.v2+json',
+    'application/vnd.oci.image.index.v1+json',
+    'application/vnd.oci.image.manifest.v1+json',
+])
+
+_TIMEOUT_SECONDS = 30
+
+
+def _split_image(image):
+  """Splits a container image reference into registry, repository, reference.
+
+  Args:
+    image: An image reference, such as
+      'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'.
+
+  Returns:
+    A (registry, repository, reference) tuple, where reference is a tag or a
+    'sha256:...' digest.
+  """
+  registry, _, remainder = image.partition('/')
+
+  # A digest reference ('repo@sha256:...') takes precedence over a tag.
+  if '@' in remainder:
+    repository, _, reference = remainder.partition('@')
+    return registry, repository, reference
+
+  # A colon is only a tag separator if it appears in the last path segment;
+  # otherwise the reference is implicitly 'latest'.
+  if ':' in remainder.rsplit('/', 1)[-1]:
+    repository, _, reference = remainder.rpartition(':')
+    return registry, repository, reference
+
+  return registry, remainder, 'latest'
+
+
+def _head(url, headers):
+  """Issues a HEAD request, returning the response for error statuses too.
+
+  Args:
+    url: The URL to request.
+    headers: A dict of request headers.
+
+  Returns:
+    Either an http.client.HTTPResponse or a urllib.error.HTTPError; both expose
+    'code' and 'headers'.
+  """
+  request = urllib.request.Request(url, headers=headers, method='HEAD')
+  try:
+    return urllib.request.urlopen(request, timeout=_TIMEOUT_SECONDS)
+  except urllib.error.HTTPError as e:
+    return e
+
+
+def _parse_bearer_challenge(header):
+  """Parses a WWW-Authenticate Bearer challenge into its parameters.
+
+  Args:
+    header: A header value such as 'Bearer realm="https://gcr.io/v2/token",
+      service="gcr.io",scope="repository:google.com/x:pull"'.
+
+  Returns:
+    A dict of the quoted challenge parameters, or None if the challenge is not
+    a Bearer challenge.
+  """
+  scheme, _, parameters = header.partition(' ')
+  if scheme.strip().lower() != 'bearer':
+    return None
+  return dict(re.findall(r'([a-zA-Z_]+)="([^"]*)"', parameters))
+
+
+def _fetch_anonymous_token(challenge):
+  """Fetches an anonymous pull token from the realm named in a challenge.
+
+  Args:
+    challenge: The parsed WWW-Authenticate parameters, which must contain
+      'realm'.
+
+  Returns:
+    A bearer token string, or None if the realm did not return one.
+
+  Raises:
+    urllib.error.HTTPError: If the realm refuses to issue an anonymous token,
+      as Artifact Registry does for repositories that are not publicly
+      readable.
+  """
+  realm = challenge.get('realm')
+  if not realm:
+    return None
+
+  query = {k: challenge[k] for k in ('service', 'scope') if challenge.get(k)}
+  url = realm
+  if query:
+    url = '{}?{}'.format(realm, urllib.parse.urlencode(query))
+
+  with urllib.request.urlopen(url, timeout=_TIMEOUT_SECONDS) as response:
+    body = json.loads(response.read().decode('utf-8'))
+
+  # Registries differ on which field carries the token.
+  return body.get('token') or body.get('access_token')
+
+
+class CloudSdkImageTest(unittest.TestCase):
+
+  def testEnvironmentVariableOverridesImage(self):
+    """DSUB_CLOUD_SDK_IMAGE lets an operator pin a known-good image."""
+    self.addCleanup(importlib.reload, google_utils)
+
+    override = 'gcr.io/google.com/cloudsdktool/cloud-sdk:537.0.0-slim'
+    with mock.patch.dict(os.environ, {'DSUB_CLOUD_SDK_IMAGE': override}):
+      reloaded = importlib.reload(google_utils)
+      self.assertEqual(override, reloaded.CLOUD_SDK_IMAGE)
+
+  def testEmptyEnvironmentVariableUsesDefaultImage(self):
+    """An unset or empty override must not produce an empty image name."""
+    self.addCleanup(importlib.reload, google_utils)
+
+    with mock.patch.dict(os.environ, {'DSUB_CLOUD_SDK_IMAGE': ''}):
+      reloaded = importlib.reload(google_utils)
+      self.assertEqual(reloaded.DEFAULT_CLOUD_SDK_IMAGE,
+                       reloaded.CLOUD_SDK_IMAGE)
+
+  def testCloudSdkImageExistsInRegistry(self):
+    """The image the providers will actually pull must resolve to a manifest."""
+    if os.environ.get('DSUB_SKIP_NETWORK_TESTS'):
+      self.skipTest('DSUB_SKIP_NETWORK_TESTS is set')
+
+    # Check the image that will actually be pulled, so that an operator
+    # who has set DSUB_CLOUD_SDK_IMAGE validates their own pin.
+    image = google_utils.CLOUD_SDK_IMAGE
+    registry, repository, reference = _split_image(image)
+    url = 'https://{}/v2/{}/manifests/{}'.format(registry, repository,
+                                                 reference)
+    headers = {'Accept': _ACCEPT_MANIFEST_TYPES}
+
+    # _head() returns HTTP error statuses rather than raising, so a URLError
+    # from it always means the registry itself was unreachable.
+    try:
+      response = _head(url, headers)
+    except urllib.error.URLError as e:
+      self.skipTest('Could not reach {}: {}'.format(registry, e))
+
+    # Public images on gcr.io answer anonymously, but Artifact Registry and
+    # Docker Hub demand a token even for public reads. Both advertise where to
+    # get one, so honor the challenge rather than hard-coding a registry. Note
+    # that a 404 never reaches this branch, so a missing image is still a
+    # failure below.
+    if response.code in (401, 403):
+      challenge = _parse_bearer_challenge(
+          response.headers.get('WWW-Authenticate', ''))
+      if not challenge:
+        self.skipTest('{} requires credentials to read {} and did not offer a '
+                      'bearer challenge (HTTP {}).'.format(
+                          registry, repository, response.code))
+
+      try:
+        token = _fetch_anonymous_token(challenge)
+      except urllib.error.HTTPError as e:
+        # Artifact Registry, for one, refuses anonymous pull tokens. An
+        # anonymous check cannot tell "deleted" from "private" in that case, so
+        # skip rather than claim a breakage that may not exist.
+        self.skipTest('{} refused an anonymous pull token for {} (HTTP {}). '
+                      'Cannot verify this image without credentials.'.format(
+                          registry, repository, e.code))
+      except urllib.error.URLError as e:
+        self.skipTest('Could not reach the token realm for {}: {}'.format(
+            registry, e))
+
+      if not token:
+        self.skipTest(
+            '{} did not return an anonymous pull token for {}.'.format(
+                registry, repository))
+
+      headers['Authorization'] = 'Bearer {}'.format(token)
+      try:
+        response = _head(url, headers)
+      except urllib.error.URLError as e:
+        self.skipTest('Could not reach {}: {}'.format(registry, e))
+
+    self.assertEqual(
+        200, response.code,
+        'CLOUD_SDK_IMAGE {!r} did not resolve in the registry (HTTP {}). '
+        'The Google providers run localization, delocalization, and logging '
+        'in this image, so jobs will fail at runtime until it is fixed. Check '
+        'whether the tag was deleted by the gcr.io retention policy, or '
+        'whether the repository was renamed. See '
+        'dsub/providers/google_utils.py.'.format(image, response.code))
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
As per https://github.com/DataBiosphere/dsub/pull/337 from shawnfan19:fix/cloud-sdk-image-retention: gcr.io now enforces a documented 1-year retention policy on the cloud-sdk image repo ([policy](https://github.com/GoogleCloudPlatform/cloud-sdk-docker#package-retention-policy)). On ~2026-09-01 it deleted every numbered tag older than 537.0.0 (2025-09) — including 499.0.0-slim pinned on main/v0.5.3/v0.5.4 and 294.0.0-slim pinned by ≤ v0.5.2. Since dsub runs all auxiliary runnables on this image, every job on the Google providers now fails ~40 s after RUNNING with exit code 1 and produces no logs (the always_run final-logging runnable cannot pull the image either). Full diagnosis and registry-level repro in https://github.com/DataBiosphere/dsub/issues/336.

This is the minimal fix: point CLOUD_SDK_IMAGE at the rolling :slim tag, which the retention policy retains, and document the policy at the definition. If maintainers prefer a pinned tag, any numbered tag ≥ 537.0.0 currently resolves (e.g. 539.0.0-slim) — with the caveat that the policy will delete it within a year, re-breaking all releases that pin it. Making CLOUD_SDK_IMAGE operator-overridable (env var) would allow self-service next time.

Verified end-to-end on Google Batch (All of Us Researcher Workbench, 2026-09-01): current :slim provides everything the runnable scripts need (bash, python3, gcloud), and with a live tag jobs complete with logs delivered. (Installs of ≤ 0.5.2 additionally need the bare-python → python3 fix that main already has; hotfix in https://github.com/DataBiosphere/dsub/issues/336.)

Fixes https://github.com/DataBiosphere/dsub/issues/336 from shawnfan19:fix/cloud-sdk-image-retention as per https://github.com/DataBiosphere/dsub/pull/337

## Additional Changes

- **`dsub/providers/google_utils.py`** — `CLOUD_SDK_IMAGE` now defaults to the
  rolling `:slim` tag, which retention retains, and is overridable via
  `DSUB_CLOUD_SDK_IMAGE` so an operator can pin a known-good image without
  waiting on a dsub release. The comment block records both directions: pinning
  fails on a schedule, while the rolling tag makes the auxiliary runnables follow
  whatever Google ships (`python3`, the `gcloud storage` flag surface).

- **`test/unit/cloud_sdk_image_test.py`** (new) — resolves the image's manifest
  against the registry and fails if it does not exist. Nothing in `test/`
  previously referenced `CLOUD_SDK_IMAGE`, so a re-pin, repo rename, or the next
  retention deletion would leave the suite green while every job failed. Parses
  the tag out of the constant, uses the anonymous Registry v2 API (no
  credentials, Docker, or gcloud), ~0.4s. Skips on unreachable registries and
  under `DSUB_SKIP_NETWORK_TESTS=1`; a registry that answers but reports the
  image missing always fails.

- **`test/integration/e2e_block_external_network.google-cls-v2.sh`** — reads
  `google_utils.CLOUD_SDK_IMAGE` instead of holding a duplicate copy of the
  reference, and its stderr assertions now match the invariant (gcloud could not
  reach the GCS endpoint) rather than one release's prose, since a blocked
  network now surfaces as `gcloud crashed (ConnectionError)` instead of
  `Max retries exceeded`.